### PR TITLE
remove the explicit dependency on sbt-idea plugin

### DIFF
--- a/project/build/Project.scala
+++ b/project/build/Project.scala
@@ -1,6 +1,6 @@
 import sbt._
 
-class Project(info: ProjectInfo) extends DefaultProject(info)  with IdeaProject {
+class Project(info: ProjectInfo) extends DefaultProject(info) {
 
   val scalaCheck = "org.scala-tools.testing" %% "scalacheck" % "1.8" % "test" withSources
   val specs = "org.scala-tools.testing" %% "specs" % "1.6.7.1" % "test" withSources

--- a/project/plugins/Plugins.scala
+++ b/project/plugins/Plugins.scala
@@ -1,5 +1,0 @@
-import sbt._
-class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
-  val sbtIdeaRepo = "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
-  val sbtIdea = "com.github.mpeltonen" % "sbt-idea-plugin" % "0.1.0"
-}


### PR DESCRIPTION
Hi Daniel,

The sbt-idea plugin version number is too old. We have the option to either bump it to 0.4.0 (see branch update-idea-plugin) or to drop it and use the plugin as a sbt processor which has two advantages:
1. It doesn't pollute the sources and reduces the start-up time of "sbt" for non-idea users.
2. The sbt-processor needs to be run once and it becomes available for all other projects on that box. Unbeatable.

Cheers
Piyush

PS: Haven't had too much time dealing with XML lately but the moment I do you can count on me using anti-xml.   
