### PR TITLE
anti-xml and HTML5

### DIFF
--- a/src/main/scala/com/codecommit/antixml/XML.scala
+++ b/src/main/scala/com/codecommit/antixml/XML.scala
@@ -77,6 +77,15 @@ class SAXParser extends XML {
     
     handler.result
   }
+
+  def fromInputSource(source: InputSource, reader: XMLReader): Group[Elem] = {
+    val handler = new NodeSeqSAXHandler
+
+    reader.setContentHandler(handler)
+    reader.parse(source)
+
+    handler.result
+  }
 }
 object XML extends SAXParser
 


### PR DESCRIPTION
Hi Daniel,

I want to use anti-xml on a HTML document. Then I've added a method to switch a parser. With my patch, we can use anti-xml with the Validator.nu HTML5 parser.

```
object HTML extends com.codecommit.antixml.SAXParser {
  import com.codecommit.antixml._
  override def fromInputSource(source: org.xml.sax.InputSource): Group[Elem] =
    fromInputSource(source, new nu.validator.htmlparser.sax.HtmlParser)
}
...
// http://www.w3.org/TR/html5/the-end.html#an-introduction-to-error-handling-and-strange-cases-in-the-parser
val doc = HTML.fromString("<p>1<b>2<i>3</b>4</i>5</p>")
```
