### PR TITLE
Updated README.rst 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ You can also pass a ``Symbol`` if that is more convenient::
     
     val xml = ...
     val books = xml \ "book"
-    val books2 = xml \ 'book       // equivalent to `books`
+    val books2 = xml \ 'book       // `books2` is equivalent to `books`
     
 You will also note that the ``*`` character is used as a wildcard selector, rather
 than the magical string value ``"_"`` (as in ``scala.xml``).  This is because


### PR DESCRIPTION
The documentation was slightly unclear: I thought some more magic was working here than actually is. The line is saying that books2 is the same as books, but it is possible to misread it as saying that using a symbol does something different than using a string.

It's a very minor fix and I can perfectly understand it if you don't want to pull it in.
