### PR TITLE
Here are my proposed changes to support namespaces

### DIFF
--- a/src/main/scala/com/codecommit/antixml/Attributes.scala
+++ b/src/main/scala/com/codecommit/antixml/Attributes.scala
@@ -138,7 +138,7 @@ object Attributes {
       new Builder[(String, String), Attributes] {
         def +=(pair: (String, String)) = {
           val (key, value) = pair
-          delegate += (QName(None, key) -> value)
+          delegate += (QName(None, key, None) -> value)
           this
         }
         

--- a/src/main/scala/com/codecommit/antixml/Group.scala
+++ b/src/main/scala/com/codecommit/antixml/Group.scala
@@ -44,7 +44,7 @@ import scala.collection.mutable.{ArrayBuffer, Builder, ListBuffer}
  * a valid `Group` could be as follows:
  *
  * {{{
- * Group(EntityRef("quot"), Text("Daniel is "), Elem(None, "em", Map(), Group(Text("delusional!"))), EntityRef("quot"))
+ * Group(EntityRef("quot"), Text("Daniel is "), Elem(QName(None, "em", None), Map(), Group(Text("delusional!"))), EntityRef("quot"))
  * }}}
  *
  * This would correspond to the following XML fragment (note: not actually well-formed
@@ -199,8 +199,8 @@ class Group[+A <: Node] private[antixml] (private[antixml] val nodes: VectorCase
     
     for (node <- nodes) {
       node match {
-        case Elem(_, name, _, children) => {
-          names += name
+        case Elem(name, _, _, children) => {
+          names += name.name
           
           childFilter = if (childFilter == null)
             children.bloomFilter

--- a/src/main/scala/com/codecommit/antixml/NodeSeqSAXHandler.scala
+++ b/src/main/scala/com/codecommit/antixml/NodeSeqSAXHandler.scala
@@ -29,6 +29,7 @@
 package com.codecommit
 package antixml
 
+import scala.collection.mutable.Stack
 import util._
 
 import org.xml.sax.{Attributes => SAXAttributes}
@@ -49,6 +50,7 @@ class NodeSeqSAXHandler extends DefaultHandler2 {
   private var elems = List[Group[Node] => Elem]()
   private val text = new StringBuilder
   private var isCDATA = false
+  private var scopes : Stack[Map[String, String]] = Stack(Map())
   
   private var builders = VectorCase.newBuilder[Node] :: Nil
   
@@ -56,7 +58,15 @@ class NodeSeqSAXHandler extends DefaultHandler2 {
     clearText()
     isCDATA = true
   }
-  
+
+  override def startPrefixMapping(prefix : String, namespace : String) {
+    scopes.push (scopes.top + (prefix -> namespace))
+  }
+
+  override def endPrefixMapping(prefix : String) {
+    scopes.pop
+  }
+
   override def endCDATA() {
     clearText()
     isCDATA = false
@@ -76,19 +86,24 @@ class NodeSeqSAXHandler extends DefaultHandler2 {
         if (back == "") None else Some(back)
       }
       
-      val localName = {
-        val back = attrs.getLocalName(i)
-        if (back == "") attrs.getQName(i) else back
+      val localName = attrs.getLocalName(i)
+
+      val prefix = {
+        val back = attrs.getQName(i)
+        if (back == localName) None else Some(back.substring(0, back.length - localName.length -1))
       }
     
-      map + (QName(ns, localName) -> attrs.getValue(i))
+      map + (QName(ns, localName, prefix) -> attrs.getValue(i))
     }
-    
+
     builders ::= VectorCase.newBuilder
     elems ::= { children =>
+      val prefix = {
+        if (qName == localName) None else Some(qName.substring(0, qName.length - localName.length -1))
+      }
       val ns = if (uri == "") None else Some(uri)
       
-      Elem(ns, localName, map, children)
+      Elem(QName(ns, localName, prefix), map, scopes.top, children)
     }
   }
 

--- a/src/main/scala/com/codecommit/antixml/QName.scala
+++ b/src/main/scala/com/codecommit/antixml/QName.scala
@@ -28,10 +28,10 @@
 
 package com.codecommit.antixml
 
-case class QName(ns: Option[String], name: String) {
-  override def toString = (ns map { _.toString + ':' } getOrElse "") + name
+case class QName(ns: Option[String], name: String, prefix: Option[String]) {
+  override def toString = (prefix map { _.toString + ':' } getOrElse "") + name
 }
 
-object QName extends ((Option[String], String) => QName) {
-  implicit def stringToQName(str: String) = QName(None, str)
+object QName extends ((Option[String], String, Option[String]) => QName) {
+  implicit def stringToQName(str: String) = QName(None, str, None)
 }

--- a/src/main/scala/com/codecommit/antixml/Selectable.scala
+++ b/src/main/scala/com/codecommit/antixml/Selectable.scala
@@ -40,7 +40,7 @@ trait Selectable[+A <: Node] {
    *
    * {{{
    * nodes flatMap {
-   *   case Elem(_, _, _, children) => children collect selector
+   *   case Elem(_, _, children) => children collect selector
    *   case _ => Group()
    * }
    * }}}

--- a/src/main/scala/com/codecommit/antixml/conversion.scala
+++ b/src/main/scala/com/codecommit/antixml/conversion.scala
@@ -115,16 +115,17 @@ trait XMLConvertable[-A, +B] {      // note: doesn't extend Function1 to avoid c
 object XMLConvertable extends SecondPrecedenceConvertables {
   implicit object ElemConvertable extends XMLConvertable[xml.Elem, Elem] {
     def apply(e: xml.Elem) = {
-      val ns = if (e.prefix == null) None else Some(e.prefix)
+      val prefix = if (e.prefix == null) None else Some(e.prefix)
+      val ns = if (e.namespace == null) None else Some(e.namespace)
         
       val attrs = (Attributes() /: e.attributes) {
-        case (attrs, pa: xml.PrefixedAttribute) => attrs + (QName(Some(pa.pre), pa.key) -> pa.value.mkString)
+        case (attrs, pa: xml.PrefixedAttribute) => attrs + (QName(Some(e.scope.getURI(pa.pre)), pa.key, Some(pa.pre)) -> pa.value.mkString)
         case (attrs, ua: xml.UnprefixedAttribute) => attrs + (ua.key -> ua.value.mkString)
         case (attrs, _) => attrs
       }
     
       val children = NodeSeqConvertable(xml.NodeSeq fromSeq e.child)
-      Elem(ns, e.label, attrs, children)
+      Elem(QName(ns, e.label, prefix), attrs, Map(), children)
     }
   }
   

--- a/src/main/scala/com/codecommit/antixml/package.scala
+++ b/src/main/scala/com/codecommit/antixml/package.scala
@@ -59,7 +59,7 @@ package object antixml {
    * For example: `ns \ "name"`
    */
   implicit def stringToSelector(name: String): Selector[Elem] =
-    Selector({ case e @ Elem(_, `name`, _, _) => e }, Some(name))
+    Selector({ case e @ Elem(QName(_, `name`, _), _, _,  _) => e }, Some(name))
 
   /**
    * Implicitly lifts a [[scala.Symbol]] into an instance of [[com.codecommit.antixml.Selector]]
@@ -85,7 +85,7 @@ package object antixml {
   // I feel justified in this global implicit since it doesn't pimp anything
   implicit def stringTupleToQNameTuple(pair: (String, String)): (QName, String) = {
     val (key, value) = pair
-    (QName(None, key), value)
+    (QName(None, key, None), value)
   }
 
   /**

--- a/src/test/scala/com/codecommit/antixml/AttributesSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/AttributesSpecs.scala
@@ -56,16 +56,16 @@ class AttributesSpecs extends Specification with ScalaCheck with XMLGenerators {
       val attrsSafe = attrs - name
       val attrs2 = attrsSafe + (name -> value)
       attrs2 must havePairs(attrsSafe.toSeq: _*)
-      attrs2 must havePair(QName(None, name) -> value)
+      attrs2 must havePair(QName(None, name, None) -> value)
     }
     
     "produce most specific Map with non-String value" in check { attrs: Attributes =>
       val value = new AnyRef
       val attrsSafe = attrs - "foo"
-      val attrs2 = attrsSafe + (QName(None, "foo") -> value)
+      val attrs2 = attrsSafe + (QName(None, "foo", None) -> value)
       validate[Map[QName, AnyRef]](attrs2)
       attrs2 must havePairs(attrsSafe.toSeq: _*)
-      attrs2 must havePair(QName(None, "foo") -> value)
+      attrs2 must havePair(QName(None, "foo", None) -> value)
     }
     
     "support removal of qname attrs" in { 
@@ -94,21 +94,21 @@ class AttributesSpecs extends Specification with ScalaCheck with XMLGenerators {
     
     "support retrieval of attributes by string" in check { (attrs: Attributes, key: String) =>
       val result = attrs get key
-      result mustEqual (attrs find { case (QName(None, `key`), _) => true case _ => false })
+      result mustEqual (attrs find { case (QName(None, `key`, None), _) => true case _ => false })
     }
     
     "produce Attributes from collection utility methods returning compatible results" in {
       val attrs = Attributes("foo" -> "bar", "baz" -> "bin")
       val attrs2 = attrs map { case (k, v) => k -> (v + "42") }
       validate[Attributes](attrs2)
-      attrs2 must havePairs(QName(None, "foo") -> "bar42", QName(None, "baz") -> "bin42")
+      attrs2 must havePairs(QName(None, "foo", None) -> "bar42", QName(None, "baz", None) -> "bin42")
     }
     
     "produce Map from collection utility methods returning incompatible results" in {
       val attrs = Attributes("foo" -> "bar", "baz" -> "bin")
       val attrs2 = attrs map { case (k, v) => k -> 42 }
       validate[Map[QName, Int]](attrs2)
-      attrs2 must havePairs(QName(None, "foo") -> 42, QName(None, "baz") -> 42)
+      attrs2 must havePairs(QName(None, "foo", None) -> 42, QName(None, "baz", None) -> 42)
     }
   }
   

--- a/src/test/scala/com/codecommit/antixml/ConversionSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ConversionSpecs.scala
@@ -28,12 +28,15 @@
 
 package com.codecommit.antixml
 
+import org.specs2.runner.JUnitRunner
+import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.ScalaCheck
 import org.scalacheck._
 
 import scala.xml
 
+@RunWith(classOf[JUnitRunner])
 class ConversionSpecs extends Specification with ScalaCheck {
   import Prop._
   
@@ -76,26 +79,26 @@ class ConversionSpecs extends Specification with ScalaCheck {
     
     "convert elem names without namespaces" in {
       val e = <test/>.anti
-      e.ns mustEqual None
-      e.name mustEqual "test"
+      e.name.ns mustEqual None
+      e.name.name mustEqual "test"
     }
     
     "convert elem names with namespaces" in {
       val e = <w:test/>.anti
-      e.ns mustEqual Some("w")
-      e.name mustEqual "test"
+      e.name.prefix mustEqual Some("w")
+      e.name.name mustEqual "test"
     }
     
     "convert elem attributes" in {
       (<test/>).anti.attrs mustEqual Map()
-      (<test a:c="1" b="foo"/>).anti.attrs mustEqual Attributes(QName(Some("a"), "c") -> "1", "b" -> "foo")
+      (<test a:c="1" b="foo" xmlns:a="a"/>).anti.attrs mustEqual Attributes(QName(Some("a"), "c", Some("a")) -> "1", "b" -> "foo")
     }
     
     "convert elem children" in {
       val e = <test>Text1<child/>Text2</test>.anti
       e.children must have size(3)
       e.children(0) mustEqual Text("Text1")
-      e.children(1) mustEqual Elem(None, "child", Attributes(), Group())
+      e.children(1) mustEqual Elem("child", Attributes(), Map(), Group())
       e.children(2) mustEqual Text("Text2")
     }
     
@@ -103,8 +106,8 @@ class ConversionSpecs extends Specification with ScalaCheck {
       xml.NodeSeq.fromSeq(Nil).anti mustEqual Group()
       
       val result = xml.NodeSeq.fromSeq(List(<test1/>, <test2/>, xml.Text("text"))).anti
-      val expected = Group(Elem(None, "test1", Attributes(), Group()),
-        Elem(None, "test2", Attributes(), Group()),
+      val expected = Group(Elem("test1", Attributes(), Map(), Group()),
+        Elem("test2", Attributes(), Map(), Group()),
         Text("text"))
         
       result mustEqual expected

--- a/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
@@ -119,5 +119,5 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
     }
   }
   
-  def elem(name: String, children: Node*) = Elem(None, name, Attributes(), Group(children: _*))
+  def elem(name: String, children: Node*) = Elem(QName(None, name, None), Attributes(), Map(), Group(children: _*))
 }

--- a/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
@@ -28,41 +28,17 @@
 
 package com.codecommit.antixml
 
+import org.specs2.runner.JUnitRunner
+import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.matcher.DataTables
 
+@RunWith(classOf[JUnitRunner])
 class NodeSpecs extends Specification with DataTables {
     
   "elements" should {
     "serialize empty elements correctly" in {
       <br/>.anti.toString mustEqual "<br/>"
-    }
-    
-    "escape reserved characters in the name" in {
-      "character" || "elem.toString" |>
-      "\""        !! "<&quot;/>"    |
-      "&"         !! "<&amp;/>"     |
-      "'"         !! "<&apos;/>"    |
-      "<"         !! "<&lt;/>"      |
-      ">"         !! "<&gt;/>"      | { (c, r) => Elem(None, c, Attributes(), Group()).toString mustEqual r }
-    }
-    
-    "escape reserved characters in the namespace" in {
-      "character" || "elem.toString" |>
-      "\""        !! "<&quot;:foo/>" |
-      "&"         !! "<&amp;:foo/>"  |
-      "'"         !! "<&apos;:foo/>" |
-      "<"         !! "<&lt;:foo/>"   |
-      ">"         !! "<&gt;:foo/>"   | { (c, r) => Elem(Some(c), "foo", Attributes(), Group()).toString mustEqual r }
-    }
-    
-    "escape reserved characters in attribute keys" in {
-      "character" || "elem.toString"         |>
-      "\""        !! "<foo &quot;=\"bar\"/>" |
-      "&"         !! "<foo &amp;=\"bar\"/>"  |
-      "'"         !! "<foo &apos;=\"bar\"/>" |
-      "<"         !! "<foo &lt;=\"bar\"/>"   |
-      ">"         !! "<foo &gt;=\"bar\"/>"   | { (c, r) => Elem(None, "foo", Attributes(c -> "bar"), Group()).toString mustEqual r }
     }
     
     "escape reserved characters in attribute values" in {
@@ -71,11 +47,12 @@ class NodeSpecs extends Specification with DataTables {
       "&"         !! "<foo bar=\"&amp;\"/>"  |
       "'"         !! "<foo bar=\"&apos;\"/>" |
       "<"         !! "<foo bar=\"&lt;\"/>"   |
-      ">"         !! "<foo bar=\"&gt;\"/>"   | { (c, r) => Elem(None, "foo", Attributes("bar" -> c), Group()).toString mustEqual r }
+      ">"         !! "<foo bar=\"&gt;\"/>"   | { (c, r) => Elem("foo", Attributes("bar" -> c), Map(), Group()).toString mustEqual r }
     }
 
     "select against self" in {
       val bookstore = <bookstore><book><title>For Whom the Bell Tolls</title><author>Hemmingway</author></book><book><title>I, Robot</title><author>Isaac Asimov</author></book><book><title>Programming Scala</title><author>Dean Wampler</author><author>Alex Payne</author></book></bookstore>.anti
+      (bookstore \ "book") mustEqual bookstore.children
       (bookstore \ "book") mustEqual bookstore.children
       (bookstore \\ "title") mustEqual (bookstore.children \\ "title")
     }

--- a/src/test/scala/com/codecommit/antixml/SAXSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/SAXSpecs.scala
@@ -28,14 +28,25 @@
 
 package com.codecommit.antixml
 
+import org.specs2.runner.JUnitRunner
+import org.junit.runner.RunWith
 import org.specs2.mutable._
 
+@RunWith(classOf[JUnitRunner])
 class SAXSpecs extends Specification {
   object SAXParser extends SAXParser
   
   "SAXParser" should {
+    "parse a simpleString and generate a single Elem" in {
+      SAXParser.fromString("<a/>") mustEqual Elem("a", Attributes(), Map(), Group())
+    }
+    
+    "parse a simpleString and generate a single Elem even with namespaces" in {
+      SAXParser.fromString("<pf:a xmlns:pf='urn:a'/>") mustEqual Elem(QName(Some("urn:a"), "a", Some("pf")), Attributes(), Map("pf" -> "urn:a"), Group())
+    }
+
     "parse a String and generate an Elem" in {
-      SAXParser.fromString("<a:a xmlns:a='a'>hi<b attr='value' /> there</a:a>") mustEqual Elem(Some("a"), "a", Attributes(), Group(Text("hi"), Elem(None, "b", Attributes("attr" -> "value"), Group()), Text(" there")))
+      SAXParser.fromString("<p:a xmlns:p='ns'>hi<b attr='value' /> there</p:a>") mustEqual Elem(QName(Some("ns"), "a", Some("p")), Attributes(), Map("p"->"ns"), Group(Text("hi"), Elem("b", Attributes("attr" -> "value"), Map("p"->"ns"), Group()), Text(" there")))
     }
   }
 }

--- a/src/test/scala/com/codecommit/antixml/StAXSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/StAXSpecs.scala
@@ -29,13 +29,16 @@
 package com.codecommit.antixml
 
 import org.specs2.mutable._
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class StAXSpecs extends Specification {
   object StAXParser extends StAXParser
   
   "StAXParser" should {
     "parse a StreamSource and generate an Elem" in {
-      StAXParser.fromString("<a:a xmlns:a='a'>hi<b attr='value' /> there</a:a>") mustEqual Elem(Some("a"), "a", Attributes(), Group(Text("hi"), Elem(None, "b", Attributes("attr" -> "value"), Group()), Text(" there")))
+      StAXParser.fromString("<a:a xmlns:a='a'>hi<b attr='value' /> there</a:a>") mustEqual Elem(QName(Some("a"), "a", Some("a")), Attributes(), Map("a" -> "a"), Group(Text("hi"), Elem(QName(None, "b", None), Attributes("attr" -> "value"), Map("a" -> "a"), Group()), Text(" there")))
     }
   }
 }

--- a/src/test/scala/com/codecommit/antixml/XMLGenerators.scala
+++ b/src/test/scala/com/codecommit/antixml/XMLGenerators.scala
@@ -81,9 +81,11 @@ trait XMLGenerators {
   def elemGenerator(depth: Int = 0): Gen[Elem] = for {
     ns <- genSaneOptionString
     name <- genSaneString
+    prefix <- genSaneOptionString
     attrs <- genAttributes
+    bindings <- genBindings
     children <- if (depth > MaxGroupDepth) value(Group()) else (listOf(nodeGenerator(depth + 1)) map Group.fromSeq)
-  } yield Elem(ns, name, attrs, children)
+  } yield Elem(QName(ns, name, prefix), attrs, bindings, children)
   
   lazy val textGenerator: Gen[Text] = genSaneString map Text
   
@@ -102,9 +104,18 @@ trait XMLGenerators {
     
     listOf(genTuple) map { Attributes(_: _*) }
   }
-  
+
+  private lazy val genBindings: Gen[Map[String, String]] = {
+    val genTuple = for {
+      qname <- genSaneString
+      value <- genSaneString
+    } yield (qname, value)
+    
+    listOf(genTuple) map { Map(_: _*) }
+  }
+
   private lazy val genQName: Gen[QName] = for {
     ns <- genSaneOptionString
     name <- genSaneString
-  } yield QName(ns, name)
+  } yield QName(ns, name, None)
 }

--- a/src/test/scala/com/codecommit/antixml/XMLSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/XMLSpecs.scala
@@ -29,7 +29,10 @@
 package com.codecommit.antixml
 
 import org.specs2.mutable._
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class XMLSpecs extends Specification {
   import XML._
   
@@ -57,6 +60,20 @@ class XMLSpecs extends Specification {
     "preserve whitespace" in {
       fromString("<test>\n  \n\t\n</test>") mustEqual elem("test", Text("\n  \n\t\n"))
     }
+
+    "preserve prefixes" in {
+      val ns = "urn:my-urn:quux";
+      fromString("<my:test xmlns:my='urn:my-urn:quux'/>") mustEqual Elem(QName(Some(ns), "test", Some("my")), Attributes(), Map("my" -> ns), Group[Node]());
+    }
+
+    "parse prefixes" in {
+      fromString("<my:test xmlns:my='urn:my-urn:quux'></my:test>").name.name mustEqual "test"
+    }
+
+    "serialize prefixes" in {
+      fromString("<my:test xmlns:my='urn:my-urn:quux'>\n<beef/>\n\t\n</my:test>").toString mustEqual "<my:test xmlns:my=\"urn:my-urn:quux\">\n<beef xmlns:my=\"urn:my-urn:quux\"/>\n\t\n</my:test>"
+    }
+
   }
   
   "fromSource" should {
@@ -68,5 +85,5 @@ class XMLSpecs extends Specification {
     }
   }
   
-  def elem(name: String, children: Node*) = Elem(None, name, Attributes(), Group(children: _*))
+  def elem(name: QName, children: Node*) = Elem(name, Attributes(), Map(), Group(children: _*))
 }

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -31,7 +31,10 @@ package com.codecommit.antixml
 import org.specs2.mutable._
 import scala.io.Source
 import org.specs2.matcher.MustExpectable._
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class ZipperSpecs extends Specification {
   val bookstore = resource("bookstore.xml")
   
@@ -65,8 +68,8 @@ class ZipperSpecs extends Specification {
       val bookstore2: Group[Node] = authors.updated(0, author0).updated(2, author2).updated(3, author3).unselect.unselect
       
       // find afresh without using \
-      bookstore2.head.asInstanceOf[Elem].name mustEqual "bookstore"
-      bookstore2.head.asInstanceOf[Elem].children(0).asInstanceOf[Elem].name mustEqual "book"
+      bookstore2.head.asInstanceOf[Elem].name.name mustEqual "bookstore"
+      bookstore2.head.asInstanceOf[Elem].children(0).asInstanceOf[Elem].name.name mustEqual "book"
       
       bookstore2.head.asInstanceOf[Elem].children(0).asInstanceOf[Elem].children must haveSize(2)
       bookstore2.head.asInstanceOf[Elem].children(0).asInstanceOf[Elem].children(1).asInstanceOf[Elem].attrs mustEqual Attributes("updated" -> "yes")
@@ -117,7 +120,7 @@ class ZipperSpecs extends Specification {
         bookElem <- bookstore \ "book"
         title <- bookElem \ "title" \ text
         if !title.trim.isEmpty
-        val filteredChildren = bookElem.children filter { case Elem(_, "title", _, _) => false case _ => true }
+        val filteredChildren = bookElem.children filter { case Elem(QName(None, "title", None), _, _, _) => false case _ => true }
       } yield bookElem.copy(attrs=(bookElem.attrs + ("title" -> title)), children=filteredChildren)
       
       val bookstore2 = titledBooks.unselect


### PR DESCRIPTION
Changes:
- Fixed confusion between namespaces and prefixes, extending QName in the process.
- Fixed the tests so that they match XML namespace rules
- "Minimal" xmlns:xxx prefix mapping still left to do.

Still to do:
- Support minimal namespace prefix output
- Support using default namespace for elements w/o parsed prefixes
- Support prefix generation for prefix collisions and attributes without parsed prefixes
- Add more implicit support for QNames?

Keep in mind, I'm not exactly a seasoned Scala developer, and my Github skills are made up as I go along.

-Jesper

Change-Id: Ie61d4684a6d44244684b316df93a3358af8b8f7c
