### PR TITLE
"where" selector for shallow filtering.

### DIFF
--- a/src/main/scala/com/codecommit/antixml/package.scala
+++ b/src/main/scala/com/codecommit/antixml/package.scala
@@ -87,7 +87,15 @@ package object antixml {
     val (key, value) = pair
     (QName(None, key), value)
   }
-
+     
+  /**
+   * Converts [[PartialFunction]]`[String, String]` into an instance of [[com.codecommit.antixml.Selector]]
+   * which can then be passed to the appropriate methods on [[com.codecommit.antixml.Group]].
+   * For example: `ns \ where { case "name" => "alternative" }`
+   */
+  def where(f: PartialFunction[String, String]): Selector[Node] =
+    Selector({ case Elem(p, name, a, s, c) if f.isDefinedAt(name) => Elem(p, f(name), a, s, c) })
+  
   /**
    * Wildcard selector which passes ''all'' nodes unmodified.  This is analogous
    * to the `"_"` selector syntax in `scala.xml`.  For example: `ns \ * \ "name"`

--- a/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
@@ -45,6 +45,14 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
       ns \ "parent" mustEqual Group(elem("parent"))
     }
     
+    "find an immediate descendant with string where clause" in {
+      val ns = fromString("<parent><a><child1/><child2/></a></parent>")
+      ns \ "a" \ where {
+        case "child1" => "foo"
+        case "child2" => "bar"
+      } mustEqual Group(elem("foo"), elem("bar"))
+    }
+    
     "be referentially transparent" in {
       val ns = fromString("<parent><parent/></parent>")
       ns \ "parent" mustEqual Group(elem("parent"))


### PR DESCRIPTION
usage:

```
val ns = fromString("<parent><a><child1/><child2/></a></parent>")
ns \ "a" \ where {
  case "child1" => "foo"
  case "child2" => "bar"
}
```

It'd be nicer if it were more generic, but an anonymous `PartialFunction` seems to require types.
Is this the functionality you had in mind?
