### PR TITLE
Context-preserving Zipper util methods

### DIFF
--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -105,8 +105,14 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
     
               (Map[Int, Int]() /: maps) { _ ++ _ }
             }
-    
-            val (_, aggregate, childMap2) = result.slice(from, to).zipWithIndex.foldLeft((0, Vector[B](), Map[Int, Set[Int]]())) {
+
+            val initialMap = Map[Int, Set[Int]]((0 to result.size).toSeq flatMap { i =>
+              childMap get(i) match {
+                case Some(s: Set[Int]) if s.size == 0 => Some((i, s))
+                case _ => None
+              }
+            } :_*)
+            val (_, aggregate, childMap2) = result.slice(from, to).zipWithIndex.foldLeft((0, Vector[B](), initialMap)) {
               case ((start, acc, childMap2), (chunk, i)) => {
                 val size = chunk.size
                 val source = inverseMap(i)

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -45,12 +45,14 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
   def stripZipper = new Group(toVectorCase)
   
   def unselect: Zipper[Node] = {
+    def superSlice(from: Int, until: Int) = super.slice(from, until).toZipper 
+    
     val nodes2 = (map zip parent.toVectorCase).foldLeft(VectorCase[Node]()) {
       case (acc, (Some((from, to, rebuild, childMap)), _: Elem)) if from == to =>
         acc :+ rebuild(Group(), childMap mapValues Function.const(Set[Int]()))
       
       case (acc, (Some((from, to, rebuild, childMap)), _: Elem)) =>
-        acc :+ rebuild(self.slice(from, to), childMap)
+        acc :+ rebuild(superSlice(from, to), childMap)
       
       case (acc, (_, e)) =>
         acc :+ e
@@ -64,16 +66,18 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
   
   override protected[this] def newBuilder = Zipper.newBuilder[A]
   
-  override def drop(n: Int) = super.drop(n).toZipper   // TODO
+  override def drop(n: Int): Zipper[A] = slice(n, size)
   
-  override def slice(from: Int, until: Int) = super.slice(from, until).toZipper   // TODO
-  
-  override def splitAt(n: Int) = {    // TODO
-    val (left, right) = super.splitAt(n)
-    (left.toZipper, right.toZipper)
+  override def slice(from: Int, until: Int): Zipper[A] = {
+    val zwi = Map[A, Int](zipWithIndex: _*)
+    collect {
+      case e if zwi(e) >= from && zwi(e) < until => e
+    }    
   }
   
-  override def take(n: Int) = super.take(n).toZipper   // TODO
+  override def splitAt(n: Int) = (take(n), drop(n))
+  
+  override def take(n: Int) = slice(0, n)
 
   override def map[B, That](f: A => B)(implicit cbf: CanBuildFrom[Zipper[A], B, That]): That = cbf match {
     case cbf: CanProduceZipper[Zipper[A], B, That] => {

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -206,6 +206,18 @@ class ZipperSpecs extends Specification with ScalaCheck with XMLGenerators {
       titles2 must haveSize(2)
       (titles2 \ text) mustEqual Vector("For Whom the Bell Tolls", "Programming Scala")
     }
+    
+    "rebuild following 2 filters at the first level" in {
+      val books = bookstore \ 'book
+      val bookstore2 = (books filter (books(1) !=) filter (books(0) !=)).unselect
+      
+      bookstore2.head must beLike {
+        case Elem(None, "bookstore", attrs, scopes, children) if attrs.isEmpty && scopes.isEmpty => {
+          children must haveSize(1)
+          children \ 'title \ text mustEqual Vector("Programming Scala")
+        }
+      }
+    }
   }
   
   "utility methods on Zipper" >> {


### PR DESCRIPTION
## specs

```
"rebuild after a drop at the first level" in {
  val books = bookstore \ "book"
  val books2 = books drop 2
  val bookstore2: Group[Node] = books2.unselect

  bookstore2 mustEqual onlyPS
}

"rebuild after a slice at the first level" in {
  val books = bookstore \ "book"
  val books2 = books slice (2, 3)
  val bookstore2: Group[Node] = books2.unselect

  bookstore2 mustEqual onlyPS
}

"rebuild after a take at the first level" in {
  val books = bookstore \ "book"
  val books2 = books take 1
  val bookstore2: Group[Node] = books2.unselect

  bookstore2 mustEqual onlyBell
}

"rebuild after a splitAt at the first level" in {
  val books = bookstore \ "book"
  val (books2, books3) = books splitAt 1
  val books4 = books3 drop 1
  val bookstore2: Group[Node] = books2.unselect
  val bookstore4: Group[Node] = books4.unselect

  bookstore2 mustEqual onlyBell
  bookstore4 mustEqual onlyPS
}
```
