### PR TITLE
Fix for issue #26

### DIFF
--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -117,10 +117,12 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
                 (start + size, acc ++ chunk, childMap2.updated(source, set2))
               }
             }
+            
+            val elided = childMap filterKeys {!childMap2.isDefinedAt(_)} mapValues {_ => Set.empty[Int]}
     
             val length = aggregate.length
             val delta = length - (to - from)
-            Some((from, to + delta, rebuild, childMap2, aggregate, delta))
+            Some((from, to + delta, rebuild, childMap2 ++ elided, aggregate, delta))
           }
           
           case None => None

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -183,6 +183,18 @@ class ZipperSpecs extends Specification with ScalaCheck with XMLGenerators {
       }
     }
     
+    "rebuild following composed filters" in {
+      val books = bookstore \ 'book
+      val bookstore2 = (books filter (books(0) !=) filter (books(1) !=)).unselect
+      
+      bookstore2.head must beLike {
+        case Elem(None, "bookstore", attrs, scopes, children) if attrs.isEmpty && scopes.isEmpty => {
+          children must haveSize(1)
+          children \ 'title \ text mustEqual Vector("Programming Scala")
+        }
+      }
+    }
+    
     "rebuild second level siblings following filter at the second level" in {
       val titles = bookstore \ 'book \ 'title
       val books2 = (titles filter (titles(1) ==)).unselect


### PR DESCRIPTION
Note that the fix could be optimized a little by handling the case where 'childMap.size == childMap2.size' specially.  In that case, 'elided' will be empty and we don't have to calculate it the long way.   Essentially, this would remove the extra childMap traversal from those cases where the code was already working correctly.  

If you think the optimization is worth adding, I'm happy to make the change.
