### PR TITLE
Remove code that came from an earlier incorrect fix for #26

### DIFF
--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -110,13 +110,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
               (Map[Int, Int]() /: maps) { _ ++ _ }
             }
 
-            val initialMap = Map[Int, Set[Int]]((0 to result.size).toSeq flatMap { i =>
-              childMap get(i) match {
-                case Some(s: Set[Int]) if s.size == 0 => Some((i, s))
-                case _ => None
-              }
-            } :_*)
-            val (_, aggregate, childMap2) = result.slice(from, to).zipWithIndex.foldLeft((0, Vector[B](), initialMap)) {
+            val (_, aggregate, childMap2) = result.slice(from, to).zipWithIndex.foldLeft((0, Vector[B](), Map[Int, Set[Int]]())) {
               case ((start, acc, childMap2), (chunk, i)) => {
                 val size = chunk.size
                 val source = inverseMap(i)


### PR DESCRIPTION
It looks like some of the code from the incorrect fix for #26 came in along with the Zipper enhancements from @eed3si9n.   I don't think it actually breaks anything since any incorrect entries in 'initialMap' will have been updated in the final childMap, but the code should be removed.

Essentially, this pull will revert the 426298dc3eeb403a435a changes to Zipper.

Sorry for the confusion.
