### PR TITLE
reuse empty Attributes instance when possible

### DIFF
--- a/src/main/scala/com/codecommit/antixml/Attributes.scala
+++ b/src/main/scala/com/codecommit/antixml/Attributes.scala
@@ -156,7 +156,7 @@ object Attributes {
   
   def newBuilder = HashMap.newBuilder[QName, String] mapResult { m: Map[QName, String] => new Attributes(m) }
   
-  val empty = apply()
+  val empty = new Attributes(Map())
   
-  def apply(attrs: (QName, String)*) = new Attributes(Map(attrs: _*))
+  def apply(attrs: (QName, String)*) = if (attrs.isEmpty) empty else new Attributes(Map(attrs: _*))
 }


### PR DESCRIPTION
This is a silly little tweak, but it resulted in a 6% improvement in the memory-usage reported by the loadSmall and loadLarge trials.   Elements with empty Attributes should be common, so I suspect those aren't isolated cases.

I happened upon this while taking a stab at issue #19, but this seems like a worthwhile change in itself.
