### PR TITLE
Deep select running slowly

### DIFF
--- a/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
+++ b/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
@@ -57,6 +57,14 @@ trait CanBuildFromWithZipper[-From, -Elem, To] { self =>
    */
   def append(left: To, right: To): To
   
+  /**
+   * Equivalent to `(left /: rest)(append)`. Subclasses may provide a more efficient
+   * implementation.
+   */
+  def appendAll(left: To, rest: TraversableOnce[To]): To = {
+    (left /: rest)(append)
+  }
+  
   def lift[CC >: To]: CanBuildFrom[From, Elem, CC] = new CanBuildFrom[From, Elem, CC] {
     def apply(from: From) = apply()
     def apply() = self(Vector())
@@ -92,6 +100,12 @@ object CanBuildFromWithZipper {
       builder ++= left
       builder ++= right
       builder.result()
-    }  
+    }
+    
+    override def appendAll(left: To, rest: TraversableOnce[To]): To = {
+      val builder = cbf() ++= left
+      rest foreach {builder ++= _}
+      builder.result()
+    }
   }
 }

--- a/src/main/scala/com/codecommit/antixml/Selectable.scala
+++ b/src/main/scala/com/codecommit/antixml/Selectable.scala
@@ -213,8 +213,7 @@ trait Selectable[+A <: Node] {
         case Elem(_, _, _, _, children) => children \\ selector
         case _ => cbf().result
       }
-      
-      ((this \ selector) /: recursive)(cbfwz.append)
+      cbfwz.appendAll(this \ selector, recursive)
     } else {
       cbf().result
     }


### PR DESCRIPTION
The `deepSelectLarge` trial in the performance tests takes about 90000 milliseconds on my device, compared to ~ 900 milliseconds for the `scala.xml` version.

Apparently, much of the time is sent in `CanBuildFromWithZipper.identityCanBuildFrom.append`.   The  problem seems to be that `append` tends to create a new instance of `To` even in cases where the concatenation should be trivial.   During `deepSelectLarge`, `append` is repeatedly called to concatenate a large Group with an empty Group, which results in a new large Group instance that is a copy of the former.

The easiest solution I found was to add an `appendAll` method to `CanBuildFromWithZipper` which replaces the fold in `Selectable.\\` .   The `identityCanBuildFrom` version can then override `appendAll` to build the entire result using a single builder, significantly reducing the number of trivial copies.

With this change, the `deepSelectLarge` trial now runs in about 630 ms on my device. 
