### PR TITLE
Some selector combinator ideas

### DIFF
--- a/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
+++ b/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
@@ -50,8 +50,8 @@ import scala.collection.mutable.Builder
  * resolution, but still accessible without requiring an explicit import.
  */
 trait CanBuildFromWithZipper[-From, -Elem, To] { self =>
-  def apply(parent: From, map: =>Vector[Option[ZContext]]): Builder[Elem, To]
-  def apply(map: =>Vector[Option[ZContext]]): Builder[Elem, To]
+  def apply(parent: From, map: =>List[ZContext]): Builder[Elem, To]
+  def apply(map: =>List[ZContext]): Builder[Elem, To]
   
   /**
    */
@@ -67,7 +67,7 @@ trait CanBuildFromWithZipper[-From, -Elem, To] { self =>
   
   def lift[CC >: To]: CanBuildFrom[From, Elem, CC] = new CanBuildFrom[From, Elem, CC] {
     def apply(from: From) = apply()
-    def apply() = self(Vector())
+    def apply() = self(List())
   }
 }
 
@@ -92,8 +92,8 @@ object CanBuildFromWithZipper {
    * on [[com.codecommit.antixml.Group]].
    */
   implicit def identityCanBuildFrom[From, Elem, To](implicit cbf: CanBuildFrom[From, Elem, To], coerce: To => Traversable[Elem]): CanBuildFromWithZipper[From, Elem, To] = new CanBuildFromWithZipper[From, Elem, To] {
-    def apply(parent: From, map: =>Vector[Option[ZContext]]) = cbf()
-    def apply(map: =>Vector[Option[ZContext]]) = cbf()
+    def apply(parent: From, map: =>List[ZContext]) = cbf()
+    def apply(map: =>List[ZContext]) = cbf()
     
     def append(left: To, right: To) = {
       val builder = cbf()

--- a/src/main/scala/com/codecommit/antixml/Group.scala
+++ b/src/main/scala/com/codecommit/antixml/Group.scala
@@ -244,8 +244,8 @@ class Group[+A <: Node] private[antixml] (private[antixml] val nodes: VectorCase
   
   override def toZipper: Zipper[A] = {
     new Group(nodes) with Zipper[A] {
-      val map = Vector()
-      def parent = error("Attempted to move up at root of the tree")
+      val contexts = List()
+      def source = error("Attempted to move up at root of the tree")
       override val hasValidContext = false
     }
   }
@@ -312,26 +312,26 @@ class Group[+A <: Node] private[antixml] (private[antixml] val nodes: VectorCase
 object Group {
   implicit def canBuildFromWithZipper[A <: Node]: CanBuildFromWithZipper[Group[_], A, Zipper[A]] = {
     new CanBuildFromWithZipper[Group[_], A, Zipper[A]] {
-      def apply(outerParent: Group[_], baseMap: =>Vector[Option[ZContext]]): Builder[A, Zipper[A]] = {
+      def apply(outerSource: Group[_], baseContexts: =>List[ZContext]): Builder[A, Zipper[A]] = {
         VectorCase.newBuilder[A] mapResult { vec =>
           new Group(vec) with Zipper[A] {
-            lazy val map = baseMap
+            override lazy val contexts = baseContexts
             
-            lazy val parent = outerParent match {
+            override lazy val source = outerSource match {
               case group: Group[Node] => group.toZipper
               case _ => error("No zipper context available")
             }
             
-            override val hasValidContext = outerParent.isInstanceOf[Group[Node]]
+            override val hasValidContext = outerSource.isInstanceOf[Group[Node]]
           }
         }
       }
       
-      def apply(baseMap: =>Vector[Option[ZContext]]): Builder[A, Zipper[A]] = {
+      def apply(baseContexts: =>List[ZContext]): Builder[A, Zipper[A]] = {
         VectorCase.newBuilder[A] mapResult { vec =>
           new Group(vec) with Zipper[A] {
-            lazy val map = baseMap
-            def parent = error("No zipper context available")
+            override lazy val contexts = baseContexts
+            override def source = error("No zipper context available")
             override val hasValidContext = false
           }
         }

--- a/src/main/scala/com/codecommit/antixml/Selectable.scala
+++ b/src/main/scala/com/codecommit/antixml/Selectable.scala
@@ -148,7 +148,7 @@ trait Selectable[+A <: Node] {
    * In other respects, this operator behaves similarly to '\' operator.  Backtrace ("zipper") operations 
    * are fully supported.
    */
-  def \^[B, That](selector: Selector[B])(implicit cbf: CanBuildFromWithZipper[Group[_], B, That]): That = {
+  def select[B, That](selector: Selector[B])(implicit cbf: CanBuildFromWithZipper[Group[_], B, That]): That = {
     implicit val cbf2 = cbf.lift[That]
     if (matches(selector)) {
       // note: this is mutable and horrible for performance reasons
@@ -252,7 +252,7 @@ trait Selectable[+A <: Node] {
    * a result set with this property is said to be ''topologically consistent'' with the original
    * XML tree.  
    *
-   * As with the '\', and '\^' operators, backtrace ("zipper") operations are fully supported.  Indeed,
+   * As with the '\', and 'select' operators, backtrace ("zipper") operations are fully supported.  Indeed,
    * backtrace support is a major advantage of topological consistency.  Without this property,
    * backtracing semmantics must provide some means of resolving conflicting updates to nodes that
    * appear in multiple localations of the result set.

--- a/src/main/scala/com/codecommit/antixml/Selectable.scala
+++ b/src/main/scala/com/codecommit/antixml/Selectable.scala
@@ -250,8 +250,7 @@ trait Selectable[+A <: Node] {
    * property on the result set:  A node contained in the result set cannot also appear
    * as a child of a node in the result set.  For the purpose of this discussion, 
    * a result set with this property is said to be ''topologically consistent'' with the original
-   * XML tree.  This operator can then be set to return the maximal topologically consistent
-   * set of results.
+   * XML tree.  
    *
    * As with the '\', and '\^' operators, backtrace ("zipper") operations are fully supported.  Indeed,
    * backtrace support is a major advantage of topological consistency.  Without this property,

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -44,16 +44,6 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
   // TODO this *may* be a poor choice of words...
   def stripZipper = new Group(toVectorCase)
     
-  
-  def inspectZipper(level: Int = 0) {
-    println(""+level+": hasValidContext = "+hasValidContext)
-    if (hasValidContext) {
-      println(""+level+": contexts = "+contexts)
-      source.inspectZipper(level + 1)
-    }
-  }
-  
-  
   /**
    * Calculates the 'unselect' replacement for a given Node in the source tree.
    *
@@ -101,8 +91,8 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
   }
   
   /**
-  * Calculates the 'unselect' replacement for each top level node in the source tree.
-  */
+   * Calculates the 'unselect' replacement for each top level node in the source tree.
+   */
   private def unselectTopLevelNodes: IndexedSeq[IndexedSeq[Node]] = {
     val (unsels, _, _) = ((Vector.empty[IndexedSeq[Node]], 0, contexts) /: source.zipWithIndex) {
       case ((acc, off, ctxs), (sourceNode, index)) => {

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -103,19 +103,18 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
         val intermedMap = map map {
           case Some((from, to, rebuild, childMap)) => {            
             val childMapSorted = (childMap.toSeq) sortWith { _._1 < _._1 } //TODO - Maybe just make childMap a SortedMap 
-            val localResults = result.slice(from,to)
             
-            
-            val (_, chunk, childMap2) = ((0, Vector[B](), Map[Int,Int]()) /: childMapSorted) {
+            val (lastOffset, chunk, childMap2) = ((from, Vector[B](), Map[Int,Int]()) /: childMapSorted) {
               case ((offset, acc, childMap2),(srcIndex, 0)) =>
                 (offset, acc, childMap2 + (srcIndex -> 0))
               
               case ((offset, acc, childMap2),(srcIndex,destCount)) => {
-                val items = localResults.slice(offset, offset+destCount).flatMap {x => x}
+                val items = result.slice(offset, offset+destCount).flatMap(identity)
                 (offset + destCount, acc ++ items, childMap2 + (srcIndex -> items.size))
               }
             }
-    
+            assert(lastOffset == to)
+            
             Some(chunk, rebuild, childMap2)
           }
           

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -36,31 +36,111 @@ import scala.collection.generic.{CanBuildFrom, FilterMonadic}
 
 trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with ScalaCompat { self =>
   // TODO dependently-typed HList, maybe?
-
-  protected def map: Vector[Option[ZContext]]
-  protected def parent: Zipper[Node]
-  protected val hasValidContext = true
   
+  protected def contexts: List[ZContext]
+  protected def source: Zipper[Node]
+  protected val hasValidContext = true
+   
   // TODO this *may* be a poor choice of words...
   def stripZipper = new Group(toVectorCase)
+    
+  
+  def inspectZipper(level: Int = 0) {
+    println(""+level+": hasValidContext = "+hasValidContext)
+    if (hasValidContext) {
+      println(""+level+": contexts = "+contexts)
+      source.inspectZipper(level + 1)
+    }
+  }
+  
+  
+  /**
+   * Calculates the 'unselect' replacement for a given Node in the source tree.
+   *
+   * @param sourceNode a node from the source tree.
+   * @param path the path to `sourceNode`
+   * @param offset the offset into this group to copy from when `path` matches the next path in `unmatchedContexts`.
+   * @param unmatchedContexts the list of ZContexts remaining to be matched (must be sorted by path, lexicographically)
+   * @return If `sourceNode` should be replaced, the return value is `Some(result, newOffset, newContexts)`
+   *         where `result` is the sequence of replacement nodes, and `newOffset` and `newContexts` reflect the
+   *         advancement of `offset` and `unmatchedContexts` past the replacement nodes.  Otherwise, the return value
+   *         is `None`.
+   */
+  private def unselectNode(sourceNode: Node, path: IndexedSeq[Int], offset: Int, unmatchedContexts: List[ZContext]): Option[(IndexedSeq[Node], Int, List[ZContext])] = {
+    import Zipper.PrefixOrder
+    
+    if (unmatchedContexts.isEmpty) 
+      None
+    else {
+      val ZContext(contextPath, contextCount) = unmatchedContexts.head
+      
+      PrefixOrder.tryCompare(path, contextPath) match {
+        case Some(0) => {           //exact match --> replace sourceNode
+          Some((toVectorCase.slice(offset, offset+contextCount), offset+contextCount, unmatchedContexts.tail))
+        }
+        case Some(n) if n < 0 => {  //prefix match --> recusrively replace sourceNode.children
+          sourceNode match {
+            case e@Elem(_,_,_,_,children) => {
+              val (children2,offset2,umContexts2) = ((Vector0:VectorCase[Node], offset, unmatchedContexts) /: (children.zipWithIndex)) {
+                case ((acc, off, ctx),(nd,i)) => {
+                  unselectNode(nd, path :+ i, off, ctx) match {
+                    case None => (acc :+ nd, off, ctx)
+                    case Some((nds, off2, ctx2)) => (acc ++ nds, off2, ctx2)
+                  }
+                }
+              }
+              Some((new Vector1(e.copy(children=new Group(children2))), offset2, umContexts2))
+            }
+            case _ => error("Context path descends through a non-element sourceNode")
+          }
+        }
+        case None => None  //Non-matching node
+        case Some(_) => error("Node path extends context path")
+      }
+    }
+  }
+  
+  /**
+  * Calculates the 'unselect' replacement for each top level node in the source tree.
+  */
+  private def unselectTopLevelNodes: IndexedSeq[IndexedSeq[Node]] = {
+    val (unsels, _, _) = ((Vector.empty[IndexedSeq[Node]], 0, contexts) /: source.zipWithIndex) {
+      case ((acc, off, ctxs), (sourceNode, index)) => {
+        unselectNode(sourceNode, Vector1(index), off, ctxs) match {
+          case None => (acc :+ Vector1(sourceNode), off, ctxs)
+          case Some((nds, off2, ctxs2)) => (acc :+ nds, off2, ctxs2)
+        }
+      }
+    }
+    unsels
+  } 
   
   def unselect: Zipper[Node] = {
-    def superSlice(from: Int, until: Int) = super.slice(from, until).toZipper 
+    val newNodeSeqs = unselectTopLevelNodes 
+    val newNodes = newNodeSeqs.flatMap(identity)(VectorCase.canBuildFrom)
     
-    val nodes2 = (map zip parent.toVectorCase).foldLeft(VectorCase[Node]()) {
-      case (acc, (Some((from, to, rebuild, childMap)), _: Elem)) if from == to =>
-        acc :+ rebuild(Group(), childMap mapValues Function.const(0))
-      
-      case (acc, (Some((from, to, rebuild, childMap)), _: Elem)) =>
-        acc :+ rebuild(superSlice(from, to), childMap)
-      
-      case (acc, (_, e)) =>
-        acc :+ e
-    }
-
-    new Group(nodes2) with Zipper[Node] {
-      val map = self.parent.map
-      def parent = self.parent.parent
+    if (!source.hasValidContext) {
+      new Group(newNodes) with Zipper[Node]{
+        override def source = error("Cannot unselect past original source")
+        override def contexts = List()
+        override val hasValidContext = false
+      }
+    } else {
+      val (sourceChunks, _) = ((Vector0:VectorCase[Range],0) /: source.contexts) {
+        case ((acc,off),ZContext(_, count)) => (acc :+ Range(off,off+count),off+count)
+      }
+      val newContexts = source.contexts zip sourceChunks map {
+        case (zctx, chunk) => {
+          val newCount = (0 /: chunk) {
+            case (sz, indx) => sz + newNodeSeqs(indx).size
+          }
+          zctx.copy(count=newCount)
+        }
+      }
+      new Group(newNodes) with Zipper[Node]{
+        override val source = self.source.source
+        override val contexts = newContexts
+      }
     }
   }
   
@@ -83,7 +163,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
     case cbf: CanProduceZipper[Zipper[A], B, That] => {
       implicit val cbfwz = cbf.lift
       
-      val builder = cbfwz(parent.asInstanceOf[Zipper[A]], map)      // oddly, the type-checker isn't handling this
+      val builder = cbfwz(source.asInstanceOf[Zipper[A]], contexts)      // oddly, the type-checker isn't handling this
       builder ++= (toVectorCase map f)
       builder.result
     }
@@ -99,38 +179,19 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
         super.flatMap(f)(cbf)     // don't try to preserve
       } else {
         val result = toVectorCase.toVector map f
-  
-        val intermedMap = map map {
-          case Some((from, to, rebuild, childMap)) => {            
-            val childMapSorted = (childMap.toSeq) sortWith { _._1 < _._1 } //TODO - Maybe just make childMap a SortedMap 
-            
-            val (lastOffset, chunk, childMap2) = ((from, Vector[B](), Map[Int,Int]()) /: childMapSorted) {
-              case ((offset, acc, childMap2),(srcIndex, 0)) =>
-                (offset, acc, childMap2 + (srcIndex -> 0))
-              
-              case ((offset, acc, childMap2),(srcIndex,destCount)) => {
-                val items = result.slice(offset, offset+destCount).flatMap(identity)
-                (offset + destCount, acc ++ items, childMap2 + (srcIndex -> items.size))
-              }
-            }
-            assert(lastOffset == to)
-            
-            Some(chunk, rebuild, childMap2)
+        
+        val (newChunks, newContexts, _) = ((Vector.empty[Vector[B]], Vector.empty[ZContext], 0) /: contexts) {
+          case((chunkAcc, ctxAcc, offset), z @ ZContext(_,0)) => 
+            (chunkAcc :+ Vector.empty[B], ctxAcc :+ z, offset)
+          case((chunkAcc, ctxAcc, offset), z @ ZContext(_,chunkSize)) => {
+            val fmNodes = result.slice(offset,offset+chunkSize).flatMap(identity)
+            val fmChunkSize = fmNodes.size
+            (chunkAcc :+ fmNodes, ctxAcc :+ z.copy(count=fmChunkSize), offset + chunkSize)
           }
-          
-          case None => None
         }
-  
-        val (_, map2, chunks) = ((0, Vector[Option[ZContext]](), Vector[Vector[B]]()) /: intermedMap) {
-          case ((offset, map2, acc), Some((chunk,rebuild,childMap))) => {
-            (offset + chunk.size, map2 :+ Some((offset, offset+chunk.size, rebuild, childMap)), acc :+ chunk)
-          }
-          
-          case ((offset, map2, acc), None) => (offset, map2 :+ None, acc)
-        }
-          
-        val builder = cbfwz(parent.asInstanceOf[Zipper[A]], map2)
-        chunks foreach (builder ++=)
+            
+        val builder = cbfwz(source.asInstanceOf[Zipper[A]], newContexts.toList)
+        newChunks foreach (builder ++=)
         builder.result
       }
     }
@@ -149,8 +210,8 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
   
   override def updated[B >: A <: Node](index: Int, node: B) = {
     new Group(super.updated(index, node).toVectorCase) with Zipper[B] {
-      val map = self.map
-      val parent = self.parent
+      override val source = self.source
+      override val contexts = self.contexts
     }
   }
   
@@ -179,9 +240,37 @@ object Zipper {
   
   def newBuilder[A <: Node] = VectorCase.newBuilder[A] mapResult { vec =>
     new Group(vec) with Zipper[A] {
-      val map = Vector()
-      def parent = error("No zipper context available")
+      val contexts = List.empty
+      def source = error("No zipper context available")
       override val hasValidContext = false
     }
   }
+  
+  /**
+   * Partial order representing the 'startsWith' relationship for sequences.
+   * 
+   * 'lteq(x, y)' if and only if y.startsWith(x)
+   */
+  private object PrefixOrder extends scala.math.PartialOrdering[Seq[Int]] {
+    override def lteq(x: Seq[Int], y:Seq[Int]): Boolean = tryCompare(x,y) match {
+      case Some(n) if n <= 0 => true
+      case _ => false
+    }
+    
+    override def tryCompare(x: Seq[Int], y:Seq[Int]): Option[Int] = {
+      val xi = x.iterator
+      val yi = y.iterator
+      while (xi.hasNext && yi.hasNext)
+        if (xi.next != yi.next)
+          return None
+      
+      if (xi.hasNext)
+        Some(1)
+      else if (yi.hasNext)
+        Some(-1)
+      else
+        Some(0)
+    }
+  }
+  
 }

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -49,7 +49,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
     
     val nodes2 = (map zip parent.toVectorCase).foldLeft(VectorCase[Node]()) {
       case (acc, (Some((from, to, rebuild, childMap)), _: Elem)) if from == to =>
-        acc :+ rebuild(Group(), childMap mapValues Function.const(Set[Int]()))
+        acc :+ rebuild(Group(), childMap mapValues Function.const(0))
       
       case (acc, (Some((from, to, rebuild, childMap)), _: Elem)) =>
         acc :+ rebuild(superSlice(from, to), childMap)
@@ -101,51 +101,35 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] with
         val result = toVectorCase.toVector map f
   
         val intermedMap = map map {
-          case Some((from, to, rebuild, childMap)) => {
-            // get the mapping from *our* indexes to source indexes
-            val inverseMap = {
-              val maps = for ((source, targets) <- childMap)
-                yield (Map[Int, Int]() /: targets) { (acc, t) => acc + (t -> source) }
-    
-              (Map[Int, Int]() /: maps) { _ ++ _ }
-            }
-
-            val (_, aggregate, childMap2) = result.slice(from, to).zipWithIndex.foldLeft((0, Vector[B](), Map[Int, Set[Int]]())) {
-              case ((start, acc, childMap2), (chunk, i)) => {
-                val size = chunk.size
-                val source = inverseMap(i)
-    
-                val contrib = Set(start until (start + size): _*)
-                val set2 = childMap2.getOrElse(source, contrib) ++ contrib
-    
-                (start + size, acc ++ chunk, childMap2.updated(source, set2))
+          case Some((from, to, rebuild, childMap)) => {            
+            val childMapSorted = (childMap.toSeq) sortWith { _._1 < _._1 } //TODO - Maybe just make childMap a SortedMap 
+            val localResults = result.slice(from,to)
+            
+            
+            val (_, chunk, childMap2) = ((0, Vector[B](), Map[Int,Int]()) /: childMapSorted) {
+              case ((offset, acc, childMap2),(srcIndex, 0)) =>
+                (offset, acc, childMap2 + (srcIndex -> 0))
+              
+              case ((offset, acc, childMap2),(srcIndex,destCount)) => {
+                val items = localResults.slice(offset, offset+destCount).flatMap {x => x}
+                (offset + destCount, acc ++ items, childMap2 + (srcIndex -> items.size))
               }
             }
-            
-            val elided = if (childMap.size == childMap2.size)
-              Set()
-            else
-              childMap filterKeys { !childMap2.isDefinedAt(_) } mapValues { _ => Set.empty[Int] }
     
-            val length = aggregate.length
-            val delta = length - (to - from)
-            Some((from, to + delta, rebuild, childMap2 ++ elided, aggregate, delta))
+            Some(chunk, rebuild, childMap2)
           }
           
           case None => None
         }
   
-        val (_, map2, chunks) = intermedMap.foldLeft((0, Vector[Option[ZContext]](), Vector[Vector[B]]())) {
-          case ((offset, map2, acc), Some((from, to, rebuild, childMap, aggregate, delta))) => {
-            val from2 = from + offset
-            val to2 = to + offset
-            val offset2 = offset + delta
-            (offset2, map2 :+ Some((from2, to2, rebuild, childMap)), acc :+ aggregate)
+        val (_, map2, chunks) = ((0, Vector[Option[ZContext]](), Vector[Vector[B]]()) /: intermedMap) {
+          case ((offset, map2, acc), Some((chunk,rebuild,childMap))) => {
+            (offset + chunk.size, map2 :+ Some((offset, offset+chunk.size, rebuild, childMap)), acc :+ chunk)
           }
           
           case ((offset, map2, acc), None) => (offset, map2 :+ None, acc)
         }
-  
+          
         val builder = cbfwz(parent.asInstanceOf[Zipper[A]], map2)
         chunks foreach (builder ++=)
         builder.result

--- a/src/main/scala/com/codecommit/antixml/package.scala
+++ b/src/main/scala/com/codecommit/antixml/package.scala
@@ -59,7 +59,7 @@ package object antixml {
    * sorted lexicographically by path.  The offset into the target zipper is then the sum of the counts of the
    * preceeding ZContexts.
    */
-  private[antixml] case class ZContext(sourcePath: Seq[Int], count: Int) 
+  private[antixml] case class ZContext(sourcePath: IndexedSeq[Int], count: Int) 
   
   /**
    * Pimps the `anti` method onto any object for which there exists a conversion

--- a/src/main/scala/com/codecommit/antixml/package.scala
+++ b/src/main/scala/com/codecommit/antixml/package.scala
@@ -46,23 +46,20 @@ package com.codecommit
  * </ul>
  */
 package object antixml {
+  
   /**
-   * `(from, to, rebuild, internal map)`.
-   *
-   * Represents the mapping from an element's child group to the corresponding Nodes in a Zipper.
+   * ZContext correlates a (possibly deep) node in a source Group to a range of top-level nodes in a Zipper.
    * 
-   * `from` and `to` denote the slice of the target Zipper corresponding to the child group.
+   * `sourcePath` represents the path to the source node.  The first element is the index in the top
+   * level group, the second is the index into that node's child group, etc.
    *
-   * `internal map` yields the number of target Nodes for a given child node's index.
+   * `count` is the number of corresponding top-level nodes in the target zipper.
    *
-   * We require the correspondence to be order preserving and to cover the target slice.  Given this fact,
-   * the above items completely determine the correspondence.
-   *
-   * `rebuild` is called to reconstruct the element for the `unzip` operation.  It is passed the slice 
-   * of the target group along with the `internal map`.  
-   * 
+   * We don't store the offset into the target zipper because in practice, we always work with a sequence of ZContexts, 
+   * sorted lexicographically by path.  The offset into the target zipper is then the sum of the counts of the
+   * preceeding ZContexts.
    */
-  private[antixml] type ZContext = (Int, Int, (Group[Node], Map[Int, Int]) => Node, Map[Int, Int])
+  private[antixml] case class ZContext(sourcePath: Seq[Int], count: Int) 
   
   /**
    * Pimps the `anti` method onto any object for which there exists a conversion

--- a/src/main/scala/com/codecommit/antixml/package.scala
+++ b/src/main/scala/com/codecommit/antixml/package.scala
@@ -46,8 +46,23 @@ package com.codecommit
  * </ul>
  */
 package object antixml {
-  // (from, to, rebuild, internal map)
-  private[antixml] type ZContext = (Int, Int, (Group[Node], Map[Int, Set[Int]]) => Node, Map[Int, Set[Int]])
+  /**
+   * `(from, to, rebuild, internal map)`.
+   *
+   * Represents the mapping from an element's child group to the corresponding Nodes in a Zipper.
+   * 
+   * `from` and `to` denote the slice of the target Zipper corresponding to the child group.
+   *
+   * `internal map` yields the number of target Nodes for a given child node's index.
+   *
+   * We require the correspondence to be order preserving and to cover the target slice.  Given this fact,
+   * the above items completely determine the correspondence.
+   *
+   * `rebuild` is called to reconstruct the element for the `unzip` operation.  It is passed the slice 
+   * of the target group along with the `internal map`.  
+   * 
+   */
+  private[antixml] type ZContext = (Int, Int, (Group[Node], Map[Int, Int]) => Node, Map[Int, Int])
   
   /**
    * Pimps the `anti` method onto any object for which there exists a conversion

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -265,7 +265,18 @@ class ZipperSpecs extends Specification with ScalaCheck with XMLGenerators {
           children must haveSize(1)
           children \ 'title \ text mustEqual Vector("Programming Scala")
         }
+      }      
+    }
+    
+    "preserve flatMap order" in {
+      val original = <top><a /></top>.convert
+      val expanded = original \ 'a flatMap {
+        case e: Elem => for(i <- 0 until 10) yield e.copy(name=e.name+i)
       }
+      val modified = expanded.unselect
+
+      modified must haveSize(1)
+      modified(0) mustEqual <top><a0 /><a1 /><a2 /><a3 /><a4 /><a5 /><a6 /><a7 /><a8 /><a9 /></top>.convert      
     }
   }
   

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -280,11 +280,11 @@ class ZipperSpecs extends Specification with ScalaCheck with XMLGenerators {
     }
   }
 
-  "zipper updates within '\\^' results" should {
+  "zipper updates within 'select' results" should {
     val topLevel = Group(<a1 ><a1b1 /><a1b2 /></a1>.convert, <a2><a2b1 /><a2b2 /></a2>.convert)
     
     "rebuild from non-trivial selector" in {
-      val second = topLevel \^ 'a2
+      val second = topLevel select 'a2
       
       val changed = second map { e=>
         e.copy(children = e.children :+ <zzz />.convert)
@@ -304,7 +304,7 @@ class ZipperSpecs extends Specification with ScalaCheck with XMLGenerators {
         case e: Elem => for(i <- 0 until 10) yield e.copy(name=e.name+i)
       }
     
-      val filtered = expanded \^ elementWhere {e:Elem => ((e.name.substring(1).toInt) % 2) == 0}
+      val filtered = expanded select elementWhere {e:Elem => ((e.name.substring(1).toInt) % 2) == 0}
 
       val modified = filtered map {e => e.copy(name="z"+e.name)}
       
@@ -316,11 +316,11 @@ class ZipperSpecs extends Specification with ScalaCheck with XMLGenerators {
     
     "rebuild from empty result set" in {
       val xml = Group(<parent><child/><child/></parent>.convert)
-      (xml \^ 'foo).unselect mustEqual xml
-      (bookstore \ 'book \^ 'foo).unselect mustEqual (bookstore \ 'book)
-      (bookstore \^ 'bookstore \^ 'foo).unselect mustEqual (bookstore \^ 'bookstore)
-      (bookstore \ 'book \^ 'foo).unselect.unselect mustEqual Group(bookstore)
-      (bookstore \^ 'bookstore \^ 'foo).unselect.unselect mustEqual Group(bookstore)
+      (xml select 'foo).unselect mustEqual xml
+      (bookstore \ 'book select 'foo).unselect mustEqual (bookstore \ 'book)
+      (bookstore select 'bookstore select 'foo).unselect mustEqual (bookstore select 'bookstore)
+      (bookstore \ 'book select 'foo).unselect.unselect mustEqual Group(bookstore)
+      (bookstore select 'bookstore select 'foo).unselect.unselect mustEqual Group(bookstore)
     }
     
   }


### PR DESCRIPTION
This code adds the following 2 selector operators (with full Zipper support)

`\^` :   Same-level selection (this was on the TODO list)
`\\!` :  "Greedy" deep selection

The second operator is similar to normal deep selection except it will not recurse into the children of a matching Node.   This ensures that the results are "topologically consistent" with the original XML tree, and removes the major impediment to defining "unselect" semantics on the result.

Under the hood, the zipper context has been generalized to handle these cases as well as the shallow select case.    This actually simplified some things;  `Zipper.flatMap` and `Selectable.\` have become noticeably shorter (at the expense of a more complex `Zipper.unselect`).
