### PR TITLE
CDATA correctness fix

### DIFF
--- a/src/main/scala/com/codecommit/antixml/node.scala
+++ b/src/main/scala/com/codecommit/antixml/node.scala
@@ -188,7 +188,7 @@ case class Text(text: String) extends Node {
  * performs escaping, use [[com.codecommit.antixml.Text]]
  */
 case class CDATA(text: String) extends Node {
-  override def toString = "<![CDATA[" + text + "]]>"
+  override def toString = "<![CDATA[" + text.replaceAllLiterally("]]>", "]]>]]&gt;<![CDATA[") + "]]>"
 }
 
 /**

--- a/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
@@ -154,5 +154,8 @@ class NodeSpecs extends Specification with DataTables with ScalaCheck with XMLGe
     "not escape reserved characters when serialized" in {
       CDATA("Lorem \" ipsum & dolor ' sit < amet > blargh").toString mustEqual "<![CDATA[Lorem \" ipsum & dolor ' sit < amet > blargh]]>"
     }
+    "switch back to normal escaping when needed" in {
+      CDATA("Lorem ]]> <script>gotcha()</script>").toString mustEqual "<![CDATA[Lorem ]]>]]&gt;<![CDATA[ <script>gotcha()</script>]]>"
+    }
   }
 }


### PR DESCRIPTION
CDATA nodes are evil. They're a hammer people use when they don't want to think about escaping. Those people will get burned, when someone types the magic sequence ]]> into a form.

This commit tests for the issue (take a look at that first, it should make clear why this is a big deal) and also fixes it.

Parsing the resulting XML will create more nodes than originally serialized. That can't be helped, unless you want to disallow creating these evil CDATA nodes in the first place.
