### PR TITLE
Zipper.slice returns incorrect result if Zipper contains equal elements

### DIFF
--- a/src/main/scala/com/codecommit/antixml/DeepZipper.scala
+++ b/src/main/scala/com/codecommit/antixml/DeepZipper.scala
@@ -2,7 +2,7 @@ package com.codecommit.antixml
 
 import DeepZipper._
 import scala.collection.generic.CanBuildFrom
-import com.codecommit.antixml.util.VectorCase
+import com.codecommit.antixml.util.{VectorCase, Vector0, Vector1}
 import scala.collection.IndexedSeqLike
 import scala.collection.GenTraversableOnce
 
@@ -80,11 +80,9 @@ sealed trait DeepZipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Deep
   override protected[this] def newBuilder = DeepZipper.newBuilder[A]
 
   // TODO copy coded from Zipper
-  override def slice(from: Int, until: Int): DeepZipper[A] = {
-    val zwi = Map[A, Int](zipWithIndex: _*)
-    collect {
-      case e if zwi(e) >= from && zwi(e) < until => e
-    }
+  override def slice(from: Int, until: Int): DeepZipper[A] = flatMapWithIndex {
+    case (e,i) if i >= from && i < until => Vector1(e)
+    case (e,_) => Vector0
   }
   override def drop(n: Int) = slice(n, size)
   override def take(n: Int) = slice(0, n)
@@ -112,6 +110,7 @@ sealed trait DeepZipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Deep
       case _ => super.flatMap(f)(cbf)
     }
   }
+
   
   /** A specialized flatMap where the mapping function receives the index of the 
    * current element as an argument. */

--- a/src/test/scala/com/codecommit/antixml/DeepZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/DeepZipperSpecs.scala
@@ -200,6 +200,16 @@ class DeepZipperSpecs extends SpecificationWithJUnit with ScalaCheck with DataTa
    *  
    *  Text selector currently don't work on the zipper.
    */
+  "DeepZipper#slice" should {
+    "work correctly in the presence of equal siblings" in {
+      val xml = Group(<a><b /><c1 /><b /><c2 /></a>.convert)
+      
+      val sliced = (xml > *).slice(1,3)
+      sliced mustEqual <a><c1 /><b /></a>.convert.children
+      sliced.unselect(0) mustEqual <a><c1 /><b /></a>.convert
+    }
+    
+  }
 
   "DeepZipper updates within '>' results" should {
     "rebuild from empty result set" in {

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -53,6 +53,23 @@ class ZipperSpecs extends Specification with ScalaCheck with XMLGenerators {
     }
   }
   
+  "Zipper#slice" should {
+    "work correctly in the presence of equal siblings" in {
+      val xml = <a><b /><c1 /><b /><c2 /></a>.convert
+      
+      val sliced = (xml \ *).slice(1,3)
+      sliced mustEqual <a><c1 /><b /></a>.convert.children
+      sliced.unselect(0) mustEqual <a><c1 /><b /></a>.convert
+    }
+    
+    "work when there's no zipper context" in {
+      val xml = <a><b /><c1 /><b /><c2 /></a>.convert
+      
+      val sliced = (xml.children).toZipper.slice(1,3)
+      sliced mustEqual <a><c1 /><b /></a>.convert.children
+    }    
+  }
+  
   "zipper updates within '\\' results" should {
     "rebuild from empty result set" in {
       val xml = Group(<parent><child/><child/></parent>.convert)


### PR DESCRIPTION
`Zipper#slice` and `DeepZipper#slice` currently assume that no two elements are equal, which isn't always true. This pull request fixes the problem by creating a `Zipper.flatMapWithIndex` and basing `slice` off of that.  Conveniently, `DeepZipper` already had such a method and only required a small change to `slice`.

Note that the `take`, `drop`, and `splitAt` methods all use `slice` internally and exhibit the same behavior.

```
scala> val x = <a><b /><b /></a>.convert \ *
x: com.codecommit.antixml.Zipper[com.codecommit.antixml.Node] = <b/><b/>

scala> x.take(1)
res0: com.codecommit.antixml.Zipper[com.codecommit.antixml.Node] = 

scala> x.take(2)
res1: com.codecommit.antixml.Zipper[com.codecommit.antixml.Node] = <b/><b/>
```
