### PR TITLE
Optimized Selector Variant

### DIFF
--- a/src/main/scala/com/codecommit/antixml/PathCreator.scala
+++ b/src/main/scala/com/codecommit/antixml/PathCreator.scala
@@ -98,9 +98,10 @@ private[antixml] object PathCreator {
   
   /** Returns true if there is a chance that applying the given selector on the group
    * would yield some results. */
-  private def dispatchSelector(s: Selector[_], g: Group[_]) = {
+  private def dispatchSelector(s: Selector[_], g: Group[Node]) = {
     s match {
       case e: ElemSelector => g matches e.elementName
+      case opt: OptimizingSelector[_] => opt.canMatchIn(g)
       case _ => true // no info about the selector, should proceed
     }
   }

--- a/src/main/scala/com/codecommit/antixml/Selector.scala
+++ b/src/main/scala/com/codecommit/antixml/Selector.scala
@@ -33,6 +33,15 @@ import scala.collection.immutable.Seq
 
 trait Selector[+A] extends PartialFunction[Node, A]
 
+trait OptimizingSelector[+A] extends Selector[A] {
+  /***
+   * Provides a hint as to whether the selector can any children or their
+   * descendants in the specified group.  Note that this is mearly a hint,
+   * `isDefinedAt` is the authoritative determinant of whether a selector matches.
+   */
+  def canMatchIn(group: Group[Node]): Boolean
+}
+
 /** A selector that selects an element by name. */
 private[antixml] class ElemSelector(val elementName: String) extends Selector[Elem] {
   // not using a case class to allow inheritance


### PR DESCRIPTION
As of #51, custom selectors can no longer leverage the bloom filter.  I'd like to try and restore that ability in a more (hopefully) palatable way:

```
trait OptimizingSelector[+A] extends Selector[A] {
  /***
   * Provides a hint as to whether the selector can any children or their
   * descendants in the specified group.  Note that this is merely a hint,
   * `isDefinedAt` is the authoritative determinant of whether a selector matches.
   */
  def canMatchIn(group: Group[Node]): Boolean
} 
```

Basically, `canMatchIn` takes the role of the old `matches` method, but with (hopefully) cleaner semantics.  Of course, implementations can call `Group.matches(String)` to reproduce the old functionality.

For some concrete examples, here are some searches that I'd like to be able to do while leveraging the bloom filter optimization:
1.  Find all elements, `e` that have a given name and a given attribute value
2.  Find all elements, `e` with a given name and return `f(e)` for some transform `f`.
3.  Find all elements, `e` that contain a child element with a given name.
