### PR TITLE
Check characters in Text, CDATA, Attribute names and Entity References.

### DIFF
--- a/src/main/scala/com/codecommit/antixml/Attributes.scala
+++ b/src/main/scala/com/codecommit/antixml/Attributes.scala
@@ -86,6 +86,13 @@ import com.codecommit.antixml.util.OrderPreservingMap
  * @see [[com.codecommit.antixml.QName]]
  */
 class Attributes(delegate: Map[QName, String]) extends Map[QName, String] with MapLike[QName, String, Attributes] {
+  import Node.CharRegex
+
+  for ((name, value) <- delegate) {
+    if (CharRegex.unapplySeq(value).isEmpty) 
+      throw new IllegalArgumentException("Illegal character in attribute value '" + value + "'")
+  }
+
   override def empty = new Attributes(Map())
   
   // totally shadowed by the overload; compiler won't even touch it without ascribing a supertype

--- a/src/main/scala/com/codecommit/antixml/XMLSerializer.scala
+++ b/src/main/scala/com/codecommit/antixml/XMLSerializer.scala
@@ -82,7 +82,7 @@ class XMLSerializer(encoding: String, outputDeclaration: Boolean) {
             ""
           } else {
             val delta = attrs map {
-              case (key, value) => key.toString + "=\"" + Node.escapeText(value) + '"'
+              case (key, value) => key.toString + "=" + Node.quoteAttribute(value)
             } mkString " "
             
             " " + delta
@@ -94,7 +94,7 @@ class XMLSerializer(encoding: String, outputDeclaration: Boolean) {
           } else {
             val delta = scopeChange map {
               case (key, value) =>
-                (if (key == "") "xmlns" else "xmlns:" + key) + "=\"" + Node.escapeText(value) + '"'
+                (if (key == "") "xmlns" else "xmlns:" + key) + "=" + Node.quoteAttribute(value)
             } mkString " "
             
             " " + delta

--- a/src/test/scala/com/codecommit/antixml/ConversionSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ConversionSpecs.scala
@@ -57,16 +57,26 @@ class ConversionSpecs extends Specification with ScalaCheck {
       validate[Node](n2)
       validate[Group[Node]](ns2)
     }
+
+    val BadChars = "([\u0000-\u0008]|[\u000B-\u000C]|[\u000E-\u001F]|[\uD800-\uDFFF]|[\uFFFF])"r
     
     "convert text nodes" in check { str: String =>
-      val node = xml.Text(str)
-      node.convert mustEqual Text(str)
+      if (BadChars.findFirstIn(str).isEmpty) {
+        val node = xml.Text(str)
+        node.convert mustEqual Text(str)
+      } else {
+        Text(str) must throwAn[IllegalArgumentException]
+      }
     }
     
     "convert entity references" in check { str: String =>
-      val ref = xml.EntityRef(str)
-      ref.convert mustEqual EntityRef(str)
-      (ref: xml.Node).convert mustEqual EntityRef(str)
+      if (BadChars.findFirstIn(str).isEmpty) {
+        val ref = xml.EntityRef(str)
+        ref.convert mustEqual EntityRef(str)
+        (ref: xml.Node).convert mustEqual EntityRef(str)
+      } else {
+        EntityRef(str) must throwAn[IllegalArgumentException]
+      }
     }
     
     "not convert groups" in {

--- a/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
@@ -152,31 +152,53 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
       func(xml) mustEqual xml
     }
   }
+
+  val BadChars = "([\u0000-\u0008]|[\u000B-\u000C]|[\u000E-\u001F]|[\uD800-\uDFFF]|[\uFFFF])"r
   
   "canonicalization" should {
     "merge two adjacent text nodes" in check { (left: String, right: String) =>
-      Group(Text(left), Text(right)).canonicalize mustEqual Group(Text(left + right))
-      Group(CDATA(left), CDATA(right)).canonicalize mustEqual Group(CDATA(left + right))
+      if (BadChars.findFirstIn(left+right).isEmpty) {
+        Group(Text(left), Text(right)).canonicalize mustEqual Group(Text(left + right))
+        Group(CDATA(left), CDATA(right)).canonicalize mustEqual Group(CDATA(left + right))
+      } else {
+        Text(left+right) must throwAn[IllegalArgumentException]
+      }
     }
     
     "merge two adjacent text nodes at end of Group" in check { (left: String, right: String) =>
-      Group(elem("foo"), elem("bar", Text("test")), Text(left), Text(right)).canonicalize mustEqual Group(elem("foo"), elem("bar", Text("test")), Text(left + right))
-      Group(elem("foo"), elem("bar", Text("test")), CDATA(left), CDATA(right)).canonicalize mustEqual Group(elem("foo"), elem("bar", Text("test")), CDATA(left + right))
+      if (BadChars.findFirstIn(left+right).isEmpty) {
+        Group(elem("foo"), elem("bar", Text("test")), Text(left), Text(right)).canonicalize mustEqual Group(elem("foo"), elem("bar", Text("test")), Text(left + right))
+        Group(elem("foo"), elem("bar", Text("test")), CDATA(left), CDATA(right)).canonicalize mustEqual Group(elem("foo"), elem("bar", Text("test")), CDATA(left + right))
+      } else {
+        Text(left+right) must throwAn[IllegalArgumentException]
+      }
     }
     
     "merge two adjacent text nodes at beginning of Group" in check { (left: String, right: String) =>
-      Group(Text(left), Text(right), elem("foo"), elem("bar", Text("test"))).canonicalize mustEqual Group(Text(left + right), elem("foo"), elem("bar", Text("test")))
-      Group(CDATA(left), CDATA(right), elem("foo"), elem("bar", Text("test"))).canonicalize mustEqual Group(CDATA(left + right), elem("foo"), elem("bar", Text("test")))
+      if (BadChars.findFirstIn(left+right).isEmpty) {
+        Group(Text(left), Text(right), elem("foo"), elem("bar", Text("test"))).canonicalize mustEqual Group(Text(left + right), elem("foo"), elem("bar", Text("test")))
+        Group(CDATA(left), CDATA(right), elem("foo"), elem("bar", Text("test"))).canonicalize mustEqual Group(CDATA(left + right), elem("foo"), elem("bar", Text("test")))
+      } else {
+        Text(left+right) must throwAn[IllegalArgumentException]
+      }
     }
     
     "merge two adjacent text nodes at depth" in check { (left: String, right: String) =>
-      Group(elem("foo", elem("bar", Text(left), Text(right)))).canonicalize mustEqual Group(elem("foo", elem("bar", Text(left + right))))
-      Group(elem("foo", elem("bar", CDATA(left), CDATA(right)))).canonicalize mustEqual Group(elem("foo", elem("bar", CDATA(left + right))))
+      if (BadChars.findFirstIn(left+right).isEmpty) {
+        Group(elem("foo", elem("bar", Text(left), Text(right)))).canonicalize mustEqual Group(elem("foo", elem("bar", Text(left + right))))
+        Group(elem("foo", elem("bar", CDATA(left), CDATA(right)))).canonicalize mustEqual Group(elem("foo", elem("bar", CDATA(left + right))))
+      } else {
+        Text(left+right) must throwAn[IllegalArgumentException]
+      }
     }
     
     "not merge adjacent text and cdata nodes" in check { (left: String, right: String) =>
-      Group(CDATA(left), Text(right)).canonicalize mustEqual Group(CDATA(left), Text(right))
-      Group(Text(left), CDATA(right)).canonicalize mustEqual Group(Text(left), CDATA(right))
+      if (BadChars.findFirstIn(left+right).isEmpty) {
+        Group(CDATA(left), Text(right)).canonicalize mustEqual Group(CDATA(left), Text(right))
+        Group(Text(left), CDATA(right)).canonicalize mustEqual Group(Text(left), CDATA(right))
+      } else {
+        Text(left+right) must throwAn[IllegalArgumentException]
+      }
     }
     
     "always preserve serialized equality" in check { g: Group[Node] =>

--- a/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/NodeSpecs.scala
@@ -49,11 +49,11 @@ class NodeSpecs extends Specification with DataTables with ScalaCheck with XMLGe
     
     "escape reserved characters in attribute values" in {
       "character" || "elem.toString"         |>
-      "\""        !! "<foo bar=\"&quot;\"/>" |
+      "\""        !! "<foo bar='\"'/>"       |
       "&"         !! "<foo bar=\"&amp;\"/>"  |
-      "'"         !! "<foo bar=\"&apos;\"/>" |
-      "<"         !! "<foo bar=\"&lt;\"/>"   |
-      ">"         !! "<foo bar=\"&gt;\"/>"   | { (c, r) => Elem(None, "foo", Attributes("bar" -> c), Map(), Group()).toString mustEqual r }
+      "'"         !! "<foo bar=\"'\"/>"      |
+      "'\"'"      !! "<foo bar='&apos;\"&apos;'/>" |
+      "<"         !! "<foo bar=\"&lt;\"/>"   | { (c, r) => Elem(None, "foo", Attributes("bar" -> c), Map(), Group()).toString mustEqual r }
     }
     
     "allow legal name identifiers" in {
@@ -146,7 +146,7 @@ class NodeSpecs extends Specification with DataTables with ScalaCheck with XMLGe
   
   "text nodes" should {
     "escape reserved characters when serialized" in {
-      Text("Lorem \" ipsum & dolor ' sit < amet > blargh").toString mustEqual "Lorem &quot; ipsum &amp; dolor &apos; sit &lt; amet &gt; blargh"
+      Text("Lorem \" ipsum & dolor ' sit < amet > blargh").toString mustEqual "Lorem \" ipsum &amp; dolor ' sit &lt; amet &gt; blargh"
     }
   }
   


### PR DESCRIPTION
All characters in XML must conform to the Regex specified in http://www.w3.org/TR/xml/#NT-Char

Added checking to throw IllegalArgumentException if an illegal character was used.

Changed Text and Attribute escaping to conform to
http://www.w3.org/TR/xml/#NT-CharData and http://www.w3.org/TR/xml/#NT-AttValue respectively.

More precisely:

Changed Attribute escaping so that &quot; and &apos; are only used when necessary, > is not escaped at all. Instead of foo="bar&quot;foo" it now writes foo='bar"foo' and instead of foo="bar&apos;foo" it now writes foo="bar'foo".

Also changed text escaping not to escape &quot; and &apos; since they are not special in text. Left escaping of > intact because (while not strictly necessary per specification) that is the simplest way to avoid the illegal ]]> sequence in text.
