### PR TITLE
Fixes for issues #47, #48, and #49

### DIFF
--- a/src/main/scala/com/codecommit/antixml/node.scala
+++ b/src/main/scala/com/codecommit/antixml/node.scala
@@ -63,7 +63,14 @@ import java.io.Writer
  * <li>[[com.codecommit.antixml.EntityRef]] – An entity reference (e.g. `&amp;`)</li>
  * </ul>
  */
-sealed trait Node
+ sealed trait Node {
+  /** 
+   * Returns the children of this node. If the node is an [[com.codecommit.antixml.Elem]], 
+   * then this method returns the element's children.  Otherwise, it returns return an empty
+   * [[com.codecommit.antixml.Group]].
+   */
+  def children = Group.empty[Node]
+ }
 
 private[antixml] object Node {
   // TODO we should probably find a way to propagate custom entities from DTDs
@@ -110,7 +117,7 @@ case class ProcInstr(target: String, data: String) extends Node {
  * Elem(None, "span", Attributes("id" -> "foo", "class" -> "bar"), Map(), Group(Text("Lorem ipsum")))
  * }}}
  */
-case class Elem(prefix: Option[String], name: String, attrs: Attributes, scope: Map[String, String], children: Group[Node]) extends Node with Selectable[Elem] {
+case class Elem(prefix: Option[String], name: String, attrs: Attributes, scope: Map[String, String], override val children: Group[Node]) extends Node with Selectable[Elem] {
   import Elem.NameRegex
   
   for (p <- prefix) {

--- a/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
@@ -89,8 +89,24 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
     }
     
     "find and linearize a deep subset of nodes" in {
-      val ns = fromString("<parent>Some text<sub1><target>sub1</target></sub1><target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target><phoney><target>phoney</target></phoney>More text<target>outside</target></parent>")
-      val result = fromString("<parent><target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target><target>outside</target><target>sub1</target><target>top3-outer</target><target>phoney</target><target>top1</target><target>top2</target></parent>")
+      val ns = fromString("<parent>" +
+        "Some text" +
+        "<sub1><target>sub1</target></sub1>" +
+        "<target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target>" +
+        "<phoney><target>phoney</target></phoney>" + 
+        "More text" +
+        "<target>outside</target>" +
+        "</parent>")
+
+      val result = fromString("<parent>" +
+        "<target>sub1</target>" +
+        "<target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target>" +
+        "<target>top1</target>" +
+        "<target>top2</target>" +
+        "<target>top3-outer</target>" +
+        "<target>phoney</target>" +
+        "<target>outside</target>" +
+        "</parent>")
       ns \\ "target" mustEqual result.children
     }
     
@@ -116,10 +132,72 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
     } */
     
     "work with an alternative selector" in {
-      val ns = fromString("<parent>Some text<sub1><target>sub1</target></sub1><target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target><phoney><target>phoney</target></phoney>More text<target>outside</target></parent>")
+      val ns = fromString("<parent>" +
+        "Some text" +
+        "<sub1><target>sub1</target></sub1>" + 
+        "<target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target>" +
+        "<phoney><target>phoney</target></phoney>" +
+        "More text" +
+        "<target>outside</target>" +
+        "</parent>")
       val strs = ns \\ text
-      strs mustEqual Vector("Some text", "More text", "top", "outside", "sub1", "top3-outer", "phoney", "top1", "top2")
+      strs mustEqual Vector("Some text", "sub1", "top", "top1", "top2", "top3-outer", "phoney", "More text", "outside")
     }
+  }
+  
+  "short-circuit deep selection on Group" should {
+
+    "find an immediate descendant" in {
+      val ns = fromString("<parent><parent/></parent>")
+      ns \\! "parent" mustEqual Group(elem("parent"))
+    }
+    
+    "find a subset of nodes" in {
+      val ns = fromString("<parent>Some<a/>text<b/>to\nreally<c/>confuse<a/><b/><d/>things<e/><a/><f/></parent>")
+      val result = Group(elem("a"), elem("a"), elem("a"))
+      ns \\! "a" mustEqual result
+    }
+    
+    "skip descendants of matching nodes in" in {
+      val ns = fromString("<parent>" +
+        "Some text" +
+        "<sub1><target>sub1</target></sub1>" +
+        "<target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target>" +
+        "<phoney><target>phoney</target></phoney>" + 
+        "More text" +
+        "<target>outside</target>" +
+        "</parent>")
+
+      val result = fromString("<parent>" +
+        "<target>sub1</target>" +
+        "<target>top<sub1><target>top1</target><target>top2</target></sub1><target>top3-outer</target></target>" +
+        "<target>phoney</target>" +
+        "<target>outside</target>" +
+        "</parent>")
+      ns \\! "target" mustEqual result.children
+    }
+        
+   }
+   
+  "select on a Group" should {
+
+    "find a top level node" in {
+      val ns = fromString("<parent><parent/></parent>")
+      (ns select "parent") mustEqual Group(ns)
+    }
+    
+    "find a subset of nodes" in {
+      val ns = fromString("<TOP><a><x1/></a><b><y1/></b><a><x2/></a><b><y2/></b></TOP>").children
+      val result = fromString("<TOP><a><x1/></a><a><x2/></a></TOP>").children
+      ns select "a" mustEqual result
+    }
+    
+    "only match the top level" in {
+      val ns = fromString("<TOP><a /><b><a /></b><a><a /></a></TOP>").children
+      val result = fromString("<TOP><a /><a><a /></a></TOP>").children
+      ns select "a" mustEqual result      
+    }
+    
   }
   
   "utility methods on Group" >> {
@@ -185,4 +263,5 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
   def elem(name: String, children: Node*) = Elem(None, name, Attributes(), Map(), Group(children: _*))
 
   def elem(qname : QName, children: Node*) = Elem(qname.prefix, qname.name, Attributes(), Map(), Group(children: _*))
+
 }

--- a/src/test/scala/com/codecommit/antixml/PathCreatorSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/PathCreatorSpecs.scala
@@ -4,12 +4,90 @@ import org.specs2.mutable._
 import com.codecommit.antixml.PathCreator._
 import com.codecommit.antixml.DeepZipper._
 import XML._
+import scala.math.Ordering
 
 class PathCreatorSpecs extends SpecificationWithJUnit {
+  
+  val s = *
 
+  val x0 = fromString("<root0><a0>foo</a0><b0>baz</b0><c0/></root0>")
+  val a0 = fromString("<a0>foo</a0>"); val b0 = fromString("<b0>baz</b0>"); val c0 = fromString("<c0/>")
+  val foo0 = Text("foo"); val baz0 = Text("baz")
+
+  val x1 = fromString("<root1><a1>foo</a1><b1>baz</b1><c1/></root1>")
+  val a1 = fromString("<a1>foo</a1>"); val b1 = fromString("<b1>baz</b1>"); val c1 = fromString("<c1/>")
+  val foo1 = Text("foo"); val baz1 = Text("baz")
+
+  val x2 = fromString("<root2><a2>foo</a2><b2>baz</b2><c2/></root2>")
+  val a2 = fromString("<a2>foo</a2>"); val b2 = fromString("<b2>baz</b2>"); val c2 = fromString("<c2/>")
+  val foo2 = Text("foo"); val baz2 = Text("baz")
+
+  val group = Group(x0, x1, x2)
+
+  def ps(pars: (Elem, Int)*) = List(pars.map(ParentLoc.tupled): _*)
+  def nl(n: Node, l: Int) = WithLoc(n, l)
+
+  val root = List((nl(x0, 0), ps()), (nl(x1, 1), ps()), (nl(x2, 2), ps()))
+  val directChild = List(
+    (nl(a0, 0), ps((x0, 0))), (nl(b0, 1), ps((x0, 0))), (nl(c0, 2), ps((x0, 0))),
+    (nl(a1, 0), ps((x1, 1))), (nl(b1, 1), ps((x1, 1))), (nl(c1, 2), ps((x1, 1))),
+    (nl(a2, 0), ps((x2, 2))), (nl(b2, 1), ps((x2, 2))), (nl(c2, 2), ps((x2, 2)))
+  )
+  val rest = List(
+    (nl(foo0, 0), ps((a0, 0), (x0, 0))), (nl(baz0, 0), ps((b0, 1), (x0, 0))),
+    (nl(foo1, 0), ps((a1, 0), (x1, 1))), (nl(baz1, 0), ps((b1, 1), (x1, 1))),
+    (nl(foo2, 0), ps((a2, 0), (x2, 2))), (nl(baz2, 0), ps((b2, 1), (x2, 2)))
+  )
+  
+  "allMaximalChildren" should {
+    "stop at the highest match" in {
+      allMaximalChildren(s)(group) mustEqual directChild.sortBy(pathKeys)
+    }
+    
+    "find deep matches" in {
+      val sel = Selector({case x:Text => x})
+      allMaximalChildren(sel)(group) mustEqual rest.sortBy(pathKeys)      
+    }
+    
+    "find matches at mixed levels" in {
+      val sel = Selector({
+        case e:Elem if e.name == "a0" => e
+        case t:Text => t
+      })
+      allMaximalChildren(sel)(group) mustEqual (directChild.take(1) ++ rest.drop(1)).sortBy(pathKeys)      
+    }
+  }
+  
+  "allMaximal" should {
+    "stop at the highest match" in {
+      allMaximal(s)(group) mustEqual root.sortBy(pathKeys)
+    }
+    
+    "find deep matches" in {
+      val sel = Selector({case x:Text => x})
+      allMaximal(sel)(group) mustEqual rest.sortBy(pathKeys)      
+    }
+    
+    "find matches at mixed levels" in {
+      val sel = Selector({
+        case e:Elem if e.name == "a0" => e
+        case t:Text => t
+      })
+      allMaximal(sel)(group) mustEqual (directChild.take(1) ++ rest.drop(1)).sortBy(pathKeys)      
+    }
+
+    "find matches at mixed levels 2" in {
+      val sel = Selector({
+        case e:Elem if e.name == "root0" || e.name=="a0" || e.name=="a1" => e
+        case t:Text => t 
+      })
+      allMaximal(sel)(group) mustEqual (root.take(1) ++ directChild.drop(3).take(1) ++ rest.drop(3)).sortBy(pathKeys)      
+    }
+  }
+  
+
+  
   "Path values" should {
-
-    val s = *
 
     "ignore empty groups" in {
       val empty = Group()
@@ -20,49 +98,21 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
       allChildren(s)(empty) mustEqual Nil
     }
 
-    val x0 = fromString("<root0><a0>foo</a0><b0>baz</b0><c0/></root0>")
-    val a0 = fromString("<a0>foo</a0>"); val b0 = fromString("<b0>baz</b0>"); val c0 = fromString("<c0/>")
-    val foo0 = Text("foo"); val baz0 = Text("baz")
-
-    val x1 = fromString("<root1><a1>foo</a1><b1>baz</b1><c1/></root1>")
-    val a1 = fromString("<a1>foo</a1>"); val b1 = fromString("<b1>baz</b1>"); val c1 = fromString("<c1/>")
-    val foo1 = Text("foo"); val baz1 = Text("baz")
-
-    val x2 = fromString("<root2><a2>foo</a2><b2>baz</b2><c2/></root2>")
-    val a2 = fromString("<a2>foo</a2>"); val b2 = fromString("<b2>baz</b2>"); val c2 = fromString("<c2/>")
-    val foo2 = Text("foo"); val baz2 = Text("baz")
-
-    val group = Group(x0, x1, x2)
-
-    def ps(pars: (Elem, Int)*) = List(pars.map(ParentLoc.tupled): _*)
-    def nl(n: Node, l: Int) = WithLoc(n, l)
-
-    val root = List((nl(x0, 0), ps()), (nl(x1, 1), ps()), (nl(x2, 2), ps()))
-    val directChild = List(
-      (nl(a0, 0), ps((x0, 0))), (nl(b0, 1), ps((x0, 0))), (nl(c0, 2), ps((x0, 0))),
-      (nl(a1, 0), ps((x1, 1))), (nl(b1, 1), ps((x1, 1))), (nl(c1, 2), ps((x1, 1))),
-      (nl(a2, 0), ps((x2, 2))), (nl(b2, 1), ps((x2, 2))), (nl(c2, 2), ps((x2, 2)))
-    )
-    val rest = List(
-      (nl(foo0, 0), ps((a0, 0), (x0, 0))), (nl(baz0, 0), ps((b0, 1), (x0, 0))),
-      (nl(foo1, 0), ps((a1, 0), (x1, 1))), (nl(baz1, 0), ps((b1, 1), (x1, 1))),
-      (nl(foo2, 0), ps((a2, 0), (x2, 2))), (nl(baz2, 0), ps((b2, 1), (x2, 2)))
-    )
 
     "take from the root of the nodes" in {
-      fromNodes(s)(group) mustEqual root
+      fromNodes(s)(group) mustEqual root.sortBy(pathKeys)
     }
 
     "take the children of the root nodes" in {
-      directChildren(s)(group) mustEqual directChild
+      directChildren(s)(group) mustEqual directChild.sortBy(pathKeys)
     }
 
-    "take all the nodes recursively, breadth first" in {
-      all(s)(group) mustEqual root ::: directChild ::: rest
+    "take all the nodes recursively, depth first" in {
+      all(s)(group) mustEqual (root ::: directChild ::: rest).sortBy(pathKeys) 
     }
 
-    "take all children nodes recursively, breadth first" in {
-      allChildren(s)(group) mustEqual directChild ::: rest
+    "take all children nodes recursively, depth first" in {
+      allChildren(s)(group) mustEqual (directChild ::: rest).sortBy(pathKeys)
     }
 
     "apply selectors at the root level" in {
@@ -94,11 +144,11 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
     )
 
     "apply selectors recursively" in {
-      all(selDeep)(group) mustEqual selResRoot ::: selResNoRoot
+      all(selDeep)(group) mustEqual (selResRoot ::: selResNoRoot).sortBy(pathKeys)
     }
 
     "apply selectors recursively on the children" in {
-      allChildren(selDeep)(group) mustEqual selResNoRoot
+      allChildren(selDeep)(group) mustEqual selResNoRoot.sortBy(pathKeys)
     }
   }
   
@@ -120,6 +170,16 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
         LocationContext(loc2.loc, p2, 0))
     }
   }
-  
+
   def elem(name: String) = Elem(None, name, Attributes(), Map(), Group())
+  
+  /** 
+   * Returns the indices of the specified PathVal starting at the top.  Note that depth-first
+   * order on PathVals is equivalent to Lexicographic order on their pathKeys.
+   */
+  def pathKeys(p: (WithLoc[_],Seq[ParentLoc])):Iterable[Location] = {
+    val (w,s) = p
+    (w.loc +: s.map(_.loc)).reverse
+  }
+  
 }


### PR DESCRIPTION
This patch makes deep selection return results in depth-first order.  It also adds the `\\!` and `select` operators.

Note that this code is not dependent on pull request #63  and can be applied directly to `zipper-replacement`.  I will merge these changes separately into my branch for #63.
