### PR TITLE
minor fixes to XMLSerializer

### DIFF
--- a/src/main/scala/com/codecommit/antixml/XMLSerializer.scala
+++ b/src/main/scala/com/codecommit/antixml/XMLSerializer.scala
@@ -67,7 +67,12 @@ class XMLSerializer(encoding: String, outputDeclaration: Boolean) {
   }
 
   def serializeDocument(elem: Elem, outputFile: File) {
-    serializeDocument(elem, new FileOutputStream(outputFile))
+    val fos = new FileOutputStream(outputFile)
+    try {
+      serializeDocument(elem, fos)
+    } finally {
+      fos.close()
+    }
   }
   
   def serialize(elem: Elem, w: Writer) {

--- a/src/main/scala/com/codecommit/antixml/XMLSerializer.scala
+++ b/src/main/scala/com/codecommit/antixml/XMLSerializer.scala
@@ -63,7 +63,9 @@ class XMLSerializer(encoding: String, outputDeclaration: Boolean) {
    * Uses the character encoding of this XMLSerializer (default is UTF-8).
    */
   def serializeDocument(elem: Elem, o: OutputStream) {
-    serializeDocument(elem, new OutputStreamWriter(o, encoding))
+    val writer = new OutputStreamWriter(o, encoding)
+    serializeDocument(elem, writer)
+    writer.flush()
   }
 
   def serializeDocument(elem: Elem, outputFile: File) {


### PR DESCRIPTION
I ran into a couple problems this morning with XMLSerializer, and these changes seem to fix them...
1. Flush the OutputStreamWriter so everything makes it into the OutputStream
2. Close the FileOutputStream
