### PR TITLE
New Performance Trials and Optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ project/plugins/src_managed/
 .project
 .classpath
 .scala_dependencies
+java.hprof.txt

--- a/src/main/scala/com/codecommit/antixml/Group.scala
+++ b/src/main/scala/com/codecommit/antixml/Group.scala
@@ -390,10 +390,12 @@ object Group {
   
   def newBuilder[A <: Node] = VectorCase.newBuilder[A] mapResult { new Group(_) }
   
+  private val theEmpty: Group[Nothing] = new Group(Vector0)
+  
   /**
    * @return An empty [[com.codecommit.antixml.Group]] with the given parameter type.
    */
-  def empty[A <: Node] = new Group[A](VectorCase.empty)
+  def empty[A <: Node]: Group[A] = theEmpty
   
   /**
    * Builds a new group with the specified set of nodes in order.  The most specific
@@ -415,6 +417,6 @@ object Group {
    * to ensure that the sequences you pass to this method are always of type
    * `Vector`, since this will avoid the penalty.
    */
-  def fromSeq[A <: Node](seq: Seq[A]) = new Group(VectorCase(seq: _*))
+  def fromSeq[A <: Node](seq: Seq[A]): Group[A] = if (seq.isEmpty) theEmpty else new Group(VectorCase(seq: _*))
 }
 

--- a/src/main/scala/com/codecommit/antixml/Group.scala
+++ b/src/main/scala/com/codecommit/antixml/Group.scala
@@ -362,10 +362,12 @@ class Group[+A <: Node] private[antixml] (private[antixml] val nodes: VectorCase
   }
 
   /** If true this group may contain an element with the given name as one of its children (recursively). */
-  def matches(elementName: String) = bloomFilter contains elementName
+  def matches(elementName: String) = 
+    if (bloomFilter eq Group.emptyBloomFilter) false else bloomFilter contains elementName
   
   /** Same as `matches(String)`, but works with hashes created by Group.bloomFilterHash. */
-  private[antixml] def matches(hash: BloomFilter.Hash) = bloomFilter containsHash hash
+  private[antixml] def matches(hash: BloomFilter.Hash) = 
+    if (bloomFilter eq Group.emptyBloomFilter) false else bloomFilter containsHash hash
 }
 
 /**

--- a/src/main/scala/com/codecommit/antixml/Group.scala
+++ b/src/main/scala/com/codecommit/antixml/Group.scala
@@ -194,7 +194,7 @@ class Group[+A <: Node] private[antixml] (private[antixml] val nodes: VectorCase
             if (newNode eq node)
               update(g, index + 1)
             else 
-              update(g.updated(index, replacements.head), index + 1)
+              update(g.updated(index, newNode), index + 1)
           } else {
             build(g, replacements, index)
           }

--- a/src/main/scala/com/codecommit/antixml/PathCreator.scala
+++ b/src/main/scala/com/codecommit/antixml/PathCreator.scala
@@ -34,157 +34,137 @@ import util.VectorCase
  /** Defines type related to paths on a tree.
   * Also contains factory methods for [[PathFunction]]s  */
 private[antixml] object PathCreator {
-
-  /** The number represents the number of the node in its parent's children list.
-   *  In case the node is root, the number is its position in the group to which it belongs.
-   */
-  private[antixml] type Location = Int
   
   /** The basic result type of a match.
    * @param value the selector result
    * @param path the top-down path to the selected node.
    */
-  private[antixml] case class PathVal[+A](value: A, path: IndexedSeq[Int])
-  
-  /** The values from a path function in raw form. */
-  type PathVals[+A] = Seq[(PathVal[A])]
-  
-  /** A function that creates paths on group, to be used when constructing zippers. */
-  type PathFunction[+A] = Group[Node] => PathVals[A]
-  
+  private[antixml] case class PathVal[+A](value: A, path: ZipperPath)
+
+  private[antixml] trait PathVals[+A] extends Traversable[PathVal[A]]
+
+  private[antixml] type PathFunction[+A] = (Group[Node]) => PathVals[A]
+
   /** Alias for the internal bottom-up path used during selection.  This must be reversed before
     * being returned in a [[PathVal]].
     */
-  private type BottomUp = List[Location]
+  private type BottomUp = List[Int]
     
-  private def reverse(rev: BottomUp) = VectorCase.fromSeq(rev.reverse)
+  private def reverse(rev: BottomUp) = ZipperPath.reversed(rev)
   
   /** A path function that selects on nodes in the given group. */
-  def fromNodes[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = {
-    collectGroup(nodes, selector, Nil)
+  def fromNodes[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = new PathVals[A] {
+    override def foreach[U] (f: (PathVal[A]) => U) {
+      forEachIn(nodes, selector, Nil, f)
+    }
   }
 
-  /** A path function that selects on the given nodes and recursively on the children (breadth first). */
-  def all[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = {
-    collectGroupRecursive(nodes, Nil, selector)
+  /** A path function that selects on the given nodes and recursively on the children (depth first). */
+  def all[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = new PathVals[A] {
+    override def foreach[U] (f: (PathVal[A]) => U) {
+      forEachInDeep(nodes, selector, Nil, f)
+    }
   }
 
   /**
    * A path function that selects on the given nodes and recursively on the children, returning those
    * matching nodes that are not themselves descendants of matching nodes. (depth first). 
    */
-  def allMaximal[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = {
-    collectMaximalRecursive(nodes, Nil, selector)
+  def allMaximal[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = new PathVals[A] {
+    override def foreach[U] (f: (PathVal[A]) => U) {
+      forEachInDeepShortCircuit(nodes, selector, Nil, f)
+    }
   }
   
   /** A path function that selects on the children of the given group. */
-  def directChildren[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = {
-    collectChildrenOfGroup(nodes, selector)
+  def directChildren[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = new PathVals[A] {
+    override def foreach[U] (f: (PathVal[A]) => U) {
+      forEachChildIn(nodes, selector, Nil, f)
+    }
   }
   
   /** A path function that selects on the recursively on all the children of the given group (breadth first). */
-  def allChildren[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = {
-    collectGroupChildren(nodes, Nil, selector) flatMap {case (g,p) => collectGroupRecursive(g,p,selector)}
+  def allChildren[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = new PathVals[A] {
+    override def foreach[U] (f: (PathVal[A]) => U) {
+      forEachChildInDeep(nodes, selector, Nil, f)
+    }
   }
 
   /** A path function that returns all the matching children that are not descendants of matching children (depth first). */
-  def allMaximalChildren[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = {
-    collectGroupChildren(nodes, Nil, selector) flatMap {case (g,p) => collectMaximalRecursive(g,p,selector)}
-  }
-  
-  /** Collects items from the given group that match the selector. */
-  private def collectGroup[A](nodes: Group[Node], s: Selector[A], p: BottomUp): PathVals[A] = {
-    dispatchSelector(s, nodes) {
-      val ni = nodes.zipWithIndex
-      for ((n, i) <- ni if s isDefinedAt n) yield PathVal(s(n),reverse(i :: p))
+  def allMaximalChildren[A](selector: Selector[A])(nodes: Group[Node]): PathVals[A] = new PathVals[A] {
+    override def foreach[U] (f: (PathVal[A]) => U) {
+      forEachChildInDeepShortCircuit(nodes, selector, Nil, f)
     }
   }
   
-  /** Collects items from the list groups that match the selector. */
-  private def collectGroups[A](groups: Seq[(Group[Node], BottomUp)], s: Selector[A]): PathVals[A] = {
-    groups flatMap {gp =>
-      val (g, p) = gp
-      collectGroup(g, s, p)
-    }
-  }
-  
-  /** Applies the group selector collection function on the children of the given group. */
-  private def collectChildrenOfGroupWith[A]
-	  (nodes: Group[Node], s: Selector[A], p: BottomUp)
-	  (toVals: (Group[Node], Selector[A], BottomUp) => PathVals[A]): PathVals[A] = {
-    dispatchSelector(s, nodes) {
-      val ni = nodes.zipWithIndex
-      ni flatMap {
-        case (e: Elem, i) => toVals(e.children, s, i :: p)
-        case _ => Nil
-      }
-    }
-  }
-    /** Collects items from the children of the given group that match the selector. */
-  private def collectChildrenOfGroup[A](nodes: Group[Node], s: Selector[A]): PathVals[A] = {
-    collectChildrenOfGroupWith(nodes, s, Nil) (collectGroup _)
-  }
-  
-  /** Recursively collects the specified node if matches the selector, followed by its matching descendants (depth first) */ 
-  private def collectNodeRecursive[A](n: Node, p: BottomUp, s: Selector[A]): PathVals[A] = {
-    val rest = collectGroupRecursive(n.children, p, s)
-    if (s.isDefinedAt(n)) PathVal(s(n), reverse(p)) +: rest
-    else rest
-  }
-  
-  /** Recursively collects items from the given group that match the selector. */
-  private def collectGroupRecursive[A](group: Group[Node], p: BottomUp, s: Selector[A]): PathVals[A] = {
-    if (group.isEmpty) Nil
-    else 
-      dispatchSelector(s, group) {
-        group.zipWithIndex flatMap {case (n,i) => collectNodeRecursive(n, i :: p, s)}
-      }
-  }
-  
-  /** 
-   * Collects the specified node if matches the selector, otherwise collects its matching descendants that are 
-   * not themselves descendants of matching nodes (depth first).
-   */ 
-  private def collectMaximalRecursive[A](n: Node, p: BottomUp, s: Selector[A]): PathVals[A] = {
-    if (s.isDefinedAt(n)) PathVal(s(n), reverse(p)) :: Nil
-    else collectMaximalRecursive(n.children,p,s)
-  }
-  
-  /** Recursively collects items from the given group that match the selector and are not descendants of matching items. */
-  private def collectMaximalRecursive[A](group: Group[Node], p: BottomUp, s: Selector[A]): PathVals[A] = {
-    if (group.isEmpty) Nil
-    else 
-      dispatchSelector(s, group) {
-        group.zipWithIndex flatMap {case (n,i) => collectMaximalRecursive(n, i :: p, s)}
-      }
-  }
-  
-  
-  /** Gathering all the children of the group that may match the selector. */
-  private def collectGroupChildren(g: Group[Node], p: BottomUp, s: Selector[_]): Seq[(Group[Node], BottomUp)] = {
-    dispatchSelector[Seq[(Group[Node], BottomUp)]](s, g)(Nil) {
-      val gi = g.zipWithIndex
-      gi flatMap {
-        case (e: Elem, i) => Some((e.children, i :: p))
-        case _ => None
+  private def forEachIn[A,U](g: Group[Node], s: Selector[A], parentPath: BottomUp, f: PathVal[A] => U) {
+    if (dispatchSelector(s,g)) {
+      for(i <- 0 until g.length) {
+        val n = g(i)
+        if (s.isDefinedAt(n))
+          f(PathVal(s(n), reverse(i :: parentPath)))
       }
     }
   }
   
-  /** If dispatching on the selector yields true, executing the given code block, otherwise returning 
-   * the default value.*/
-  private def dispatchSelector[A](s: Selector[_], g: Group[Node])(default: A)(vals: => A): A = {
-    if (dispatchSelector(s, g)) vals
-    else default
+  private def forEachInDeep[A,U](g: Group[Node], s: Selector[A], parentPath: BottomUp, f: PathVal[A] => U) {
+    if (dispatchSelector(s,g)) {
+      for(i <- 0 until g.length) {
+        val n = g(i)
+        if (s.isDefinedAt(n))
+          f(PathVal(s(n), reverse(i :: parentPath)))
+        val ch = n.children
+        if (!ch.isEmpty)
+          forEachInDeep(ch, s, i :: parentPath, f)
+      }
+    }
+  }
+  
+  private def forEachInDeepShortCircuit[A,U](g: Group[Node], s: Selector[A], parentPath: BottomUp, f: PathVal[A] => U) {
+    if (dispatchSelector(s,g)) {
+      for(i <- 0 until g.length) {
+        val n = g(i)
+        if (s.isDefinedAt(n))
+          f(PathVal(s(n), reverse(i :: parentPath)))
+        else {
+          val ch = n.children
+          if (!ch.isEmpty)
+            forEachInDeepShortCircuit(ch, s, i :: parentPath, f)
+        }
+      }
+    }
+  }
+  
+  private def forEachChildIn[A,U](g: Group[Node], s: Selector[A], parentPath: BottomUp, f: PathVal[A] => U) {
+    if (dispatchSelector(s,g)) {
+      for(i <- 0 until g.length) {
+        val ch = g(i).children
+        if (!ch.isEmpty)
+          forEachIn(ch,s, i::parentPath, f)
+      }
+    }
   }
 
-  /** If dispatching on the selector yields true, executing the given code block, otherwise returning
-   *  an empty list.
-   */
-  private def dispatchSelector[A](s: Selector[A], g: Group[Node])(vals: => PathVals[A]): PathVals[A] = {
-    dispatchSelector[PathVals[A]](s, g)(Nil)(vals)
+  private def forEachChildInDeep[A,U](g: Group[Node], s: Selector[A], parentPath: BottomUp, f: PathVal[A] => U) {
+    if (dispatchSelector(s,g)) {
+      for(i <- 0 until g.length) {
+        val ch = g(i).children
+        if (!ch.isEmpty)
+          forEachInDeep(ch,s, i::parentPath, f)
+      }
+    }
   }
-  
+
+  private def forEachChildInDeepShortCircuit[A,U](g: Group[Node], s: Selector[A], parentPath: BottomUp, f: PathVal[A] => U) {
+    if (dispatchSelector(s,g)) {
+      for(i <- 0 until g.length) {
+        val ch = g(i).children
+        if (!ch.isEmpty)
+          forEachInDeepShortCircuit(ch,s, i::parentPath, f)
+      }
+    }
+  }
+    
   /** Returns true if there is a chance that applying the given selector on the group
    * would yield some results. */
   private def dispatchSelector(s: Selector[_], g: Group[Node]) = {

--- a/src/main/scala/com/codecommit/antixml/Selectable.scala
+++ b/src/main/scala/com/codecommit/antixml/Selectable.scala
@@ -159,7 +159,7 @@ trait Selectable[+A <: Node] {
    *
    * @usecase def \\!(selector: Selector[Node]): Zipper[Node]
    */
-  def \\![B, That](selector: Selector[B])(implicit cbfwz: CanBuildFromWithZipper[Group[_ <: Node], B, That]): That = {
+  def \\![B, That](selector: Selector[B])(implicit cbfwz: CanBuildFromWithZipper[Group[A], B, That]): That = {
     fromPathFunc(allMaximalChildren(selector), cbfwz)
   }
   
@@ -177,7 +177,7 @@ trait Selectable[+A <: Node] {
    *
    * @usecase def select(selector: Selector[Node]): Zipper[Node]
    */
-  def select[B, That](selector: Selector[B])(implicit cbfwz: CanBuildFromWithZipper[Group[_ <: Node], B, That]): That = {
+  def select[B, That](selector: Selector[B])(implicit cbfwz: CanBuildFromWithZipper[Group[A], B, That]): That = {
     fromPathFunc(fromNodes(selector),cbfwz)
   }
 

--- a/src/main/scala/com/codecommit/antixml/Selector.scala
+++ b/src/main/scala/com/codecommit/antixml/Selector.scala
@@ -54,10 +54,11 @@ object Selector {
       private val pf: PartialFunction[Node, Elem] = {
         case e @ Elem(_, `name`, _, _, _) => e
       }
+      private val hash = Group.bloomFilterHash(name)
 
       def apply(node: Node) = pf(node)
       def isDefinedAt(node: Node) = pf isDefinedAt node
-      def canMatchIn(group: Group[Node]) = group.matches(name)
+      def canMatchIn(group: Group[Node]) = group.matches(hash)
     }
   
 

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -29,9 +29,10 @@
 package com.codecommit.antixml
 
 import com.codecommit.antixml.util.VectorCase
-import scala.collection.{IndexedSeqLike, GenTraversableOnce}
+import scala.annotation.tailrec
+import scala.collection.{immutable, mutable, IndexedSeqLike, GenTraversableOnce}
 import scala.collection.generic.{CanBuildFrom, FilterMonadic}
-import scala.collection.immutable.{SortedMap, IndexedSeq, Seq}
+import scala.collection.immutable.{SortedMap, IndexedSeq}
 import scala.collection.mutable.Builder
 
 import Zipper._
@@ -138,40 +139,59 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
    *   - A method such as `++`, is used to "add" nodes to a zipper without replacing existing nodes. 
    *   
    **/
-  def parent: Option[Zipper[Node]]
+  val parent: Option[Zipper[Node]]
   
   private def parentOrError = parent getOrElse sys.error("Root has no parent")
 
   /** Context information corresponding to each node in the zipper. */
-  protected def metas: IndexedSeq[(Path, Time)]
+  protected def metas: VectorCase[(ZipperPath, Time)]
 
-  /** 
-   * Information corresponding to each path in the zipper. The map's values consist of the indices of the corresponding nodes, 
-   * along with a master update time for the path.  An empty sequence indicates the path has been elided and should be 
-   * removed upon `unselect`.  In this case, the update time indicates the time of elision.
-   * 
-   * The map is sorted lexicographically by the path primarily to facilitate the `isBeneathPath` method.
-   */
-  protected def pathIndex: SortedMap[Path,(IndexedSeq[Int], Time)]
-
+  /** Additional (path,time) pairs associated with the zipper.  This is mainly used to
+    * keep track of holes that have had all of their correpsonding nodes deleted, but
+    * it's fine for it to contain paths that are also associated with nodes.  During
+    * unselect, each hole will be associated with the latest associated update time 
+    * found in this list or in `metas`.
+    */
+  protected def additionalHoles: immutable.Seq[(ZipperPath,Time)]
+  
   override protected[this] def newBuilder = Zipper.newBuilder[A]
   
-  override def updated[B >: A <: Node](index: Int, node: B): Zipper[B] = {
-    val updatedTime = time + 1
-    val (updatedPath,_) = metas(index)
-    val (updatePathIndices,_) = pathIndex(updatedPath)
-    
-    new Group(super.updated(index, node).toVectorCase) with Zipper[B] {
-      def parent = self.parent
-      val time = updatedTime      
-      val metas = self.metas.updated(index, (updatedPath, updatedTime))
-      val pathIndex = self.pathIndex.updated(updatedPath,(updatePathIndices, updatedTime))
+  override def updated[B >: A <: Node](index: Int, node: B): Zipper[B] = parent match {
+    case Some(_) => {
+      val updatedTime = time + 1
+      val (updatedPath,_) = metas(index)
+      
+      new Group(nodes.updated(index, node)) with Zipper[B] {
+        val parent = self.parent
+        val time = updatedTime      
+        val metas = self.metas.updated(index, (updatedPath, updatedTime))
+        val additionalHoles = self.additionalHoles
+      }
     }
+    case None => brokenZipper(nodes.updated(index,node))
   }
 
-  override def slice(from: Int, until: Int): Zipper[A] = flatMapWithIndex {
-    case (e, i) if i >= from && i < until => VectorCase(e)
-    case (e, _) => VectorCase()
+  override def slice(from: Int, until: Int): Zipper[A] = parent match {
+    case Some(_) => {
+      val lo = math.min(math.max(from, 0), nodes.length)
+      val hi = math.min(math.max(until, lo), nodes.length)
+      val cnt = hi - lo
+      
+      val ahs = new AdditionalHolesBuilder()
+      ahs ++= additionalHoles
+      for(i <- 0 until lo)
+        ahs += ((metas(i)._1, time + 1 + i))
+      for(i <- hi until nodes.length)
+        ahs += ((metas(i)._1, time + 1 + i - cnt))
+      
+      new Group(nodes.slice(from,until)) with Zipper[A] {
+        val parent = self.parent
+        val time = self.time + self.length - cnt
+        val metas = self.metas.slice(from,until)
+        val additionalHoles = ahs.result()
+      }
+    }
+    case None => brokenZipper(nodes.slice(from,until))
   }
    
   override def drop(n: Int) = slice(n, size)
@@ -192,15 +212,23 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
     flatMap(liftedF)(cbf)
   }
 
-  override def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit cbf: CanBuildFrom[Zipper[A], B, That]): That = {
-    cbf match {
-      // subtypes of this are the only expected types, hence ignoring type erasure
-      case cbf: CanProduceZipper[Zipper[A], B, That] => {
-        val liftedF = (x: (A, Int)) => f(x._1)
-        flatMapWithIndex(liftedF)(cbf.lift)
+  override def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit cbf: CanBuildFrom[Zipper[A], B, That]): That = cbf match {
+    case cpz: CanProduceZipper[Zipper[A], B, That] if parent.isDefined => {
+      val b = cpz.lift(parent, this)
+      for(i <- 0 until nodes.length) {
+        val (path,time) = metas(i)
+        b += ElemsWithContext(path, time, f(nodes(i)))
       }
-      
-      case _ => super.flatMap(f)(cbf)
+      for ((path,time) <- additionalHoles) {
+        b += ElemsWithContext[B](path,time,util.Vector0)
+      }
+      b.result()
+    }
+    case _ => {
+      val b = cbf(this)
+      for(n <- nodes)
+        b ++= f(n).seq
+      b.result()
     }
   }
   
@@ -228,107 +256,160 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
    */
   def stripZipper = new Group(toVectorCase)
   
-  /** A specialized flatMap where the mapping function receives the index of the 
-   * current element as an argument. */
-  private def flatMapWithIndex[B, That](f: ((A, Int)) => GenTraversableOnce[B])(implicit cbfwdz: CanBuildFromWithZipper[Zipper[A], B, That]): That = {
-    val result = toVector.zipWithIndex map {x => (f(x),x._2)}
-    
-    val builder = cbfwdz(parent, this)
-    for ( (items, index) <- result) {
-      val (path, _) = metas(index)
-      builder += ElemsWithContext[B](path, time+index+1, items)
-    }
-    //Add any paths that had been previously emptied out.  (TODO - Can optimize this)
-    for ( (path,(inds,time)) <- pathIndex) {
-      if (inds.isEmpty)
-        builder += ElemsWithContext[B](path,time,VectorCase.empty)
-    }
-    builder.result
-  }
-
-  /** Returns true iff the specified path is one of the contexts maintained by the zipper. */
-  private[antixml] def containsPath(p: Path) = pathIndex.contains(p)
-  
-  /** Returns true iff the specified path is the ancestor of one of the contexts maintained by the zipper. */
-  private[antixml] def isBeneathPath(p: Path) = {
-    //This would be easier if OrderedMap had a variant of the `from` method that was exclusive.
-    val ifp = pathIndex.keySet.from(p)
-    val result = for {
-      h <- ifp.headOption
-      h2 <- if (h != p) Some(h) else ifp.take(2).tail.headOption
-    } yield h2.startsWith(p) && h2.length != p.length
-    result.getOrElse(false)    
-  }
-
-  /** 
-   * Returns the direct updates for the specified path.  The result is unspecified  if the path is not contained
-   * in the zipper.  
-   * @return the time of last update to the path followed by a sequence of the direct update nodes and their update times.  
-   **/
-  private def directUpdatesFor(p: Path): (IndexedSeq[(A,Time)], Time) = {
-    val (indices, time) = pathIndex(p)
-    (indices map {x => (self(x), metas(x)._2)}, time)
+  /**
+   * Optionally replaces each node with 0 to many nodes. Used by `unselect`.  See same-named function in `Group` for more details.
+   */
+  private [antixml] override def conditionalFlatMapWithIndex[B >: A <: Node] (f: (A, Int) => Option[scala.collection.Seq[B]]): Zipper[B] = {
+    /* See the Group implementation for information about how this function is optimized. */ 
+    parent match {
+      case None => brokenZipper(new Group(nodes).conditionalFlatMapWithIndex(f).nodes)
+      case Some(_) => {
+        //Optimistic function that uses `update`
+        @tailrec
+        def update(z: Zipper[B], index: Int): Zipper[B] = {
+          if (index>=z.length)
+            z
+          else {
+            val node = nodes(index)
+            val fval = f(node, index)
+            if (!fval.isDefined)
+              update(z,index + 1)
+            else {
+              val replacements = fval.get
+              if (replacements.lengthCompare(1)==0) {
+                val newNode = replacements.head
+                if (newNode eq node)
+                  update(z, index + 1)
+                else 
+                  update(z.updated(index, replacements.head), index + 1)
+              } else {
+                build(z, replacements, index)
+              }
+            }
+          }
+        }
+        
+        //Fallback function that uses a builder
+        def build(z: Zipper[B], currentReplacements: Seq[B], index: Int): Zipper[B] = {
+          val b = newZipperContextBuilder[B](parent)
+          
+          for(i <- 0 until index) {
+            val (p,t) = z.metas(i)
+            b += ElemsWithContext(p,t,util.Vector1(z(i)))
+          }
+          b += ElemsWithContext(metas(index)._1, z.time+1,currentReplacements)
+          for(i <- (index + 1) until nodes.length) {
+            val n = nodes(i)
+            val fv = f(n,i)
+            b += ElemsWithContext(metas(i)._1, z.time + 1 + i - index, fv.getOrElse(util.Vector1(n)))
+          }
+          for((p,t) <- additionalHoles) {
+            b += ElemsWithContext(p,t,util.Vector0)
+          }
+          
+          b.result      
+        }
+        
+        update(this, 0)
+      }
+    }    
   }
   
   /** Applies the node updates to the parent and returns the result. */
-  def unselect(implicit mergeStrategy: ZipperMergeStrategy): Zipper[Node] = {
-    //TODO - Should we pull back update times as well as nodes?
-    parentOrError flatMapWithIndex {
-      case (node,index) => pullBack(node, VectorCase(index), mergeStrategy)._1
-    }
-  }
+  def unselect(implicit zms: ZipperMergeStrategy): Zipper[Node] = 
+    new Unselector(zms).unselect 
+  
+  /** Utility class to perform unselect.  */
+  private[this] class Unselector(mergeStrategy: ZipperMergeStrategy) {
     
-  /**
-   * Returns the pullback of a path. 
-   * @param node the node that is at the specified path in the zipper's parent
-   * @param path the path
-   * @return the pullback nodes along with the path's latest update time.
-   */
-  private def pullBack(node: Node, path: Path, mergeStrategy: ZipperMergeStrategy): (IndexedSeq[Node], Time) = node match {
-    case elem: Elem if isBeneathPath(path) => {
-      val childPullBacks @ (childGroup, childTime) = pullBackChildren(elem.children, path, mergeStrategy)
-      val indirectUpdate = elem.copy(children = childGroup)
-      if (containsPath(path)) {
-        mergeConflicts(elem, directUpdatesFor(path), (indirectUpdate, childTime), mergeStrategy)
+    /** Each hole is associated with a list of node/time pairs as well as a master update time */
+    type HoleInfo = ZipperHoleMap[(VectorCase[(A,Time)],Time)]
+    
+    private val topLevelHoleInfo: HoleInfo = {
+      val init:(VectorCase[(A,Time)],Time) = (util.Vector0,0)
+      val hm0: HoleInfo = ZipperHoleMap.empty
+      val hm1 = (hm0 /: (0 until self.length)) { (hm, i) =>
+        val item = self(i)
+        val (path,time) = metas(i)
+        val (oldItems, oldTime) = hm.getDeep(path).getOrElse(init)
+        val newItems = oldItems :+ (item, time)
+        val newTime = math.max(oldTime, time)
+        hm.updatedDeep(path, (newItems, newTime))
+      }
+      (hm1 /: additionalHoles) { case (hm,(path,time)) =>
+        val (oldItems, oldTime) = hm.getDeep(path).getOrElse(init)
+        val newTime = math.max(oldTime, time)
+        hm.updatedDeep(path, (oldItems, newTime))
+      }
+    }
+    
+    /** Applies the node updates to the parent and returns the result. */
+    def unselect: Zipper[Node] = 
+      pullBackGroup(parentOrError, topLevelHoleInfo)._1.asInstanceOf[Zipper[Node]]
+    
+    /**
+     * Returns the pullback of the nodes in the specified group.
+     * @param nodes the group containing the nodes to pull back.
+     * @param holeInfo the HoleInfo corresponding to the group.
+     * @return the pullBacks of the groups children, concatenated together, along with the latest update
+     * time.
+     */
+    private[this] def pullBackGroup(nodes: Group[Node], holeInfo: HoleInfo): (Group[Node], Time) = {
+      var mxt: Int = 0
+      val updatedGroup = nodes.conditionalFlatMapWithIndex[Node] { (node,index) => node match {
+        case elem:Elem if (holeInfo.hasChildrenAt(index)) => {
+          val (newNodes, time) = pullUp(elem, index, holeInfo)
+          mxt = math.max(mxt,time)
+          Some(newNodes)
+        }
+        case _ if holeInfo.contains(index) => {
+          val (newNodes, time) = holeInfo(index)
+          mxt = math.max(mxt, time)
+          Some(newNodes.map {_._1})
+        }
+        case _ => None
+      }}
+      (updatedGroup,mxt)
+    }
+    
+    /**
+     * Returns the pullback of an element that is known to be above a hole (and thus has
+     * child updates that need to be pulled up).
+     *
+     * @param elem the element
+     * @param indexInParent the index of the element in its parent
+     * @param holeInfo the HoleInfo corresponding to the parent group
+     * @return the pulled back nodes and their combined update time
+     *
+     * @note assumes `holeInfo.hasChildrenAt(indexInParent) == true`
+     */
+    private[this] def pullUp(elem: Elem, indexInParent: Int, holeInfo: HoleInfo): (VectorCase[Node], Time) = {
+      //Recursively pull back children 
+      val (childGrp, childTime) = pullBackGroup(elem.children, holeInfo.children(indexInParent))
+      val indirectUpdate = elem.copy(children = childGrp)
+      if (holeInfo.contains(indexInParent)) {
+        //This is a conflicted hole, so merge.
+        mergeConflicts(elem, holeInfo(indexInParent), (indirectUpdate, childTime))
       } else {
+        //No conflicts, just let the child updates bubble up
         (VectorCase(indirectUpdate), childTime)
       }
     }
-    case _ if containsPath(path) => {
-      val (items, time) = directUpdatesFor(path)
-      (items.map(_._1), time)
+ 
+    /**
+     * Merges updates at a conflicted node in the tree.  See the unselection algorithm, above, for more information. 
+     * @param node the conflicted node
+     * @param directUpdates the direct updates to `node`.
+     * @param indirectUpdate the indirectUpdate to `node`.
+     * @return the sequence of nodes to replace `node`, along with an overall update time for `node`.
+     */
+    private def mergeConflicts(node: Elem, directUpdates: (IndexedSeq[(Node,Time)], Time) , indirectUpdate: (Node, Time)): (VectorCase[Node], Time) = {
+      val mergeContext = ZipperMergeContext(original=node, lastDirectUpdate = directUpdates._2, directUpdate = directUpdates._1,
+          indirectUpdate = indirectUpdate)
+       
+      val result = mergeStrategy(mergeContext)
+      (VectorCase.fromSeq(result), math.max(directUpdates._2, indirectUpdate._2))
     }
-    case _ => (VectorCase(node), 0)
-  }
-
-  /**
-   * Returns the pullback of the children of a path in the zipper's parent tree. 
-   * @param node the node that is at the specified path in the zipper's parent
-   * @param path the path
-   * @return the pullBacks of the path's children, concatenated together, along with the latest update
-   * time of the child paths.
-   */
-  private def pullBackChildren(nodes: IndexedSeq[Node], path: Path, mergeStrategy: ZipperMergeStrategy): (Group[Node], Time) = {
-    val childPullbacks = nodes.zipWithIndex.map {
-      case (node, index) => pullBack(node, path :+ index, mergeStrategy)
-    }
-    (childPullbacks.flatMap[Node,Group[Node]](_._1), childPullbacks.maxBy(_._2)._2)
-  }
-  
-  /**
-   * Merges updates at a conflicted node in the tree.  See the unselection algorithm, above, for more information. 
-   * @param node the conflicted node
-   * @param directUpdates the direct updates to `node`.
-   * @param indirectUpdate the indirectUpdate to `node`.
-   * @param mergeStrategy the merge strategy
-   * @return the sequence of nodes to replace `node`, along with an overall update time for `node`.
-   */
-  private def mergeConflicts(node: Elem, directUpdates: (IndexedSeq[(Node,Time)], Time) , indirectUpdate: (Node, Time), mergeStrategy: ZipperMergeStrategy): (IndexedSeq[Node], Time) = {
-    val mergeContext = ZipperMergeContext(original=node, lastDirectUpdate = directUpdates._2, directUpdate = directUpdates._1,
-        indirectUpdate = indirectUpdate)
-     
-    val result = mergeStrategy(mergeContext)
-    (VectorCase.fromSeq(result), math.max(directUpdates._2, indirectUpdate._2))
   }
 }
 
@@ -339,17 +420,9 @@ object Zipper {
   /** The units in which time is measured in the zipper. Assumed non negative. */
   private type Time = Int
   
-  /** A top-down path used to represent a location in the Group tree.*/
-  private type Path = VectorCase[Int]
-  
-  private implicit object PathOrdering extends Ordering[Path] {
-    override def compare(x: Path, y: Path) =
-      Ordering.Iterable[Int].compare(x,y)
-  }
-  
   implicit def canBuildFromWithZipper[A <: Node] = {
     new CanBuildFromWithZipper[Traversable[_], A, Zipper[A]] {      
-      override def apply(parent: Option[Zipper[Node]]): Builder[ElemsWithContext[A],Zipper[A]] = new WithZipperBuilder[A](parent)
+      override def apply(parent: Option[Zipper[Node]]) = newZipperContextBuilder(parent)
     }
   }
   
@@ -362,63 +435,101 @@ object Zipper {
     }
   }
   
-  def newBuilder[A <: Node] = VectorCase.newBuilder[A].mapResult({new Group(_).toZipper})
+  /** Returns a builder that produces a zipper without a parent */
+  def newBuilder[A <: Node] = VectorCase.newBuilder[A].mapResult(brokenZipper(_))
+
+  /** Returns a builder that produces a zipper with a full zipper context */
+  private def newZipperContextBuilder[A <: Node](parent: Option[Zipper[Node]]) = parent match {
+    case Some(_) => new WithZipperBuilder[A](parent)
+    case None => brokenZipperBuilder[A]
+  }
   
   /** Returns a "broken" zipper which contains the specified nodes but cannot be unselected */
   private[antixml] def brokenZipper[A <: Node](nodes: VectorCase[A]): Zipper[A] = {
-    val fakePath = VectorCase(0)
     new Group[A](nodes) with Zipper[A] {
-      override def parent = None      
+      override val parent = None      
       override val time = 0
-      override val metas = constant((fakePath,0), nodes.length)
-      override val pathIndex = SortedMap( fakePath -> (0 until nodes.length, 0))
+      override val metas = null //Should never be accesseed
+      override val additionalHoles = null //Should never be accessed
     }
   }
   
-  private def constant[A](a: A, sz: Int) = new IndexedSeq[A] {
-    override def apply(i: Int) = a
-    override def length = sz
-  }
-  
+  /** Ignores context and builds a "broken" zipper */
+  private def brokenZipperBuilder[A <: Node]: Builder[ElemsWithContext[A],Zipper[A]] = 
+    CanBuildFromWithZipper.identityCanBuildFrom(VectorCase.canBuildFrom[A])(None) mapResult(brokenZipper(_))
+
   /**
    * The primary builder class used to construct Zippers. 
    */
   private class WithZipperBuilder[A <: Node](parent: Option[Zipper[Node]]) extends Builder[ElemsWithContext[A],Zipper[A]] { self =>
-    private val innerBuilder = VectorCase.newBuilder[(Path, Time, A)]
-    private var pathIndex = SortedMap.empty[Path,(IndexedSeq[Int], Time)]
+    
+    import scala.collection.mutable.HashMap
+    
+    private val itemsBuilder = VectorCase.newBuilder[A]
+    private val metasBuilder = VectorCase.newBuilder[(ZipperPath,Time)]
+    private val additionalHolesBuilder = new AdditionalHolesBuilder()
     private var size = 0
     private var maxTime = 0
     
     override def += (ewc: ElemsWithContext[A]) = {      
       val ElemsWithContext(pseq, time, ns) = ewc
-      val path = VectorCase.fromSeq(pseq)
-
-      val items = ns.seq.toSeq.map(x => (path, time, x))(VectorCase.canBuildFrom)
-      innerBuilder ++= items
+      val path: ZipperPath = ZipperPath.fromSeq(pseq)
+      val pathTime = (path, time)
       
-      val (oldIndices, oldTime) = pathIndex.getOrElse(path, (VectorCase.empty,0))
-      val (newIndices, newTime) = (math.max(oldTime, time), oldIndices ++ (size until (size + items.length)))
-      pathIndex = pathIndex.updated(path, (newTime,newIndices))
+      var nsz = 0
+      for(n <- ns) {
+        itemsBuilder += n
+        metasBuilder += pathTime
+        nsz += 1
+      }
+      if (nsz==0) {
+        additionalHolesBuilder += pathTime
+      }
       
-      size += items.length
+      size += nsz
       maxTime = math.max(maxTime, time)
       this            
     }
     override def clear() {
-      innerBuilder.clear()
-      pathIndex = SortedMap.empty
+      itemsBuilder.clear()
+      metasBuilder.clear()
+      additionalHolesBuilder.clear()
       size = 0
       maxTime = 0
     }
     override def result(): Zipper[A] = {
-      val res = innerBuilder.result()
-      new Group[A](res map {case (_,_,node) => node}) with Zipper[A] {
-        override def parent = self.parent      
+      val itemsResult = itemsBuilder.result()
+      val metasResult = metasBuilder.result()
+      val additionalHolesResult = additionalHolesBuilder.result()
+      maxTime = math.max(maxTime, size)
+      
+      new Group[A](itemsResult) with Zipper[A] {
+        override val parent = self.parent      
         override val time = maxTime
-        override val metas = res map {case (path,time,_) => (path,time)}
-        override val pathIndex = self.pathIndex
+        override val metas = metasResult
+        override val additionalHoles = additionalHolesResult
       }
     }
   }
   
+  /** Builder for the `additionalHoles` list.  This builder ensures that the result has at most one
+   *  entry for any given ZipperPath.  Although this isn't necessary for correctness, it ensures that
+   *  the `additionalHoles` list remains bounded in size by the total number of holes.
+   */
+  private class AdditionalHolesBuilder extends Builder[(ZipperPath,Time), immutable.Seq[(ZipperPath,Time)]] {0
+    private val hm = mutable.HashMap[ZipperPath,Time]()
+   
+    def += (elem: (ZipperPath,Time)) = {
+      val (p,t) = elem
+      val t2 = hm.getOrElse(p,0)
+      hm.put(p,math.max(t,t2))
+      this
+    }
+    def clear() {
+      hm.clear
+    }
+    def result = 
+      if (hm.size==0) util.Vector0 
+      else (VectorCase.newBuilder[(ZipperPath,Time)] ++= hm).result
+  }
 }

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -217,7 +217,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
       val b = cpz.lift(parent, this)
       for(i <- 0 until nodes.length) {
         val (path,time) = metas(i)
-        b += ElemsWithContext(path, time, f(nodes(i)))
+        b += ElemsWithContext(path, time+i+1, f(nodes(i)))
       }
       for ((path,time) <- additionalHoles) {
         b += ElemsWithContext[B](path,time,util.Vector0)

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -277,11 +277,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
             else {
               val replacements = fval.get
               if (replacements.lengthCompare(1)==0) {
-                val newNode = replacements.head
-                if (newNode eq node)
-                  update(z, index + 1)
-                else 
-                  update(z.updated(index, replacements.head), index + 1)
+                update(z.updated(index, replacements.head), index + 1)
               } else {
                 build(z, replacements, index)
               }
@@ -300,8 +296,12 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
           b += ElemsWithContext(metas(index)._1, z.time+1,currentReplacements)
           for(i <- (index + 1) until nodes.length) {
             val n = nodes(i)
+            val m = metas(i)
             val fv = f(n,i)
-            b += ElemsWithContext(metas(i)._1, z.time + 1 + i - index, fv.getOrElse(util.Vector1(n)))
+            if (fv.isDefined)
+              b += ElemsWithContext(m._1, z.time + 1 + i - index, fv.get)
+            else
+              b += ElemsWithContext(m._1, m._2, util.Vector1(n))
           }
           for((p,t) <- additionalHoles) {
             b += ElemsWithContext(p,t,util.Vector0)

--- a/src/main/scala/com/codecommit/antixml/ZipperHoleMap.scala
+++ b/src/main/scala/com/codecommit/antixml/ZipperHoleMap.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+
+import util.{VectorCase}
+import scala.annotation.tailrec
+import scala.collection.immutable.{Map, IndexedSeq}
+import scala.collection.{Traversable}
+
+/** Used by `Zipper` to associate information with its "holes".
+ *
+ * The `ZipperHoleMap` has a similar tree structure to `Group` and is used to maintain
+ * information about selected locations within the `Group` tree.  It differs from `Group`
+ * in the following respects:
+ *   - It allows arbitrary element types.
+ *   - It maintains its children separately from its elements
+ *   - It is sparse; Only a subset of it's indices are valued.
+ *
+ * This structure can also be viewed as a map from `ZipperPath` to `B`, although it does
+ * not actually implement the `Map` trait.
+ *
+ * @tparam the element type of the `ZipperHoleMap`. 
+ * @see [[com.codecommit.antixml.Zipper]]
+ */
+private[antixml] final class ZipperHoleMap[+B] private (items: Map[Int, ZipperHoleMap.HoleMapNode[B]]) { self =>
+  import ZipperHoleMap._
+  
+  private def find(i: Int): HoleMapNode[B] = 
+    items.getOrElse(i,unusedLocation)
+
+  /** Returns the value at the specified position or throws an exception if there is no
+   *  such value (if `contains(loc) == false`).
+   */
+  def apply(loc: Int): B = find(loc).value.get
+
+  /** Returns the value at the specified position or `None` if there is no
+   *  such value (if `contains(loc) == false`).
+   */
+  def get(loc: Int): Option[B] = find(loc).value
+  
+  /** Tests whether the hole map contains a value at the specified position */
+  def contains(loc: Int): Boolean = find(loc).value.isDefined
+
+  /** Returns the children at the specified position or throws an exception if there are
+   *  no children there (if `hasChildrenAt(loc) == false`).
+   */
+  def children(loc: Int):ZipperHoleMap[B] = find(loc).children.get
+  
+  /** Tests whether the hole map has children at the specified position */
+  def hasChildrenAt(loc: Int): Boolean = find(loc).children.isDefined
+  
+  /** Returns the value at the deep location at the specified path, or `None` if there is
+   *  no such value.
+   */
+  def getDeep(path: ZipperPath): Option[B] = getDeep(path, 0)
+  
+  @tailrec
+  private def getDeep(path: ZipperPath, from: Int): Option[B] = {
+    if (from==(path.length - 1))
+      get(path.valueAt(from))
+    else find(path(from)) match {
+      case HoleMapNode(_, Some(c)) => c.getDeep(path,from+1)
+      case _ => None
+    }
+  }    
+  
+  /** Creates a new `ZipperHoleMap` by updating the value at the specified deep location. */
+  final def updatedDeep[B2 >: B](path: ZipperPath, value: B2): ZipperHoleMap[B2] = updatedDeep(path,0,value)
+  
+  private def updatedDeep[B2 >: B](path: ZipperPath, from: Int, value: B2): ZipperHoleMap[B2] = {
+    val loc = path.valueAt(from)
+    val HoleMapNode(v,c) = find(loc)
+    if (from == (path.length - 1))
+      new ZipperHoleMap(items.updated(loc, HoleMapNode(Some(value), c)))
+    else {
+      val updatedChildren = c.getOrElse(empty).updatedDeep(path,from+1,value)
+      new ZipperHoleMap(items.updated(loc, HoleMapNode(v, Some(updatedChildren))))
+    }
+  }
+
+  /** Returns a traversable represented the tree's contents in pre-order (lexicographically by path).
+   * Note that this has not been optimized, as it is only currenly used by toString and for testing.
+   */
+  def depthFirst: Traversable[(ZipperPath, B)] = 
+    new Traversable[(ZipperPath, B)] {
+      override def foreach[U] (f: ((ZipperPath, B)) => U) {
+        self.traverseDepthFirst(Nil, f)
+      }
+    }
+  
+  private def traverseDepthFirst[U](parents : List[Int], f: ((ZipperPath, B)) => U) {
+    val sortedItems = items.toSeq.sortBy(_._1)
+    sortedItems foreach {case (loc,node) =>
+      val p2 = loc :: parents
+      if (node.value.isDefined)
+        f((ZipperPath.reversed(p2), node.value.get))
+      if (node.children.isDefined)
+        node.children.get.traverseDepthFirst(p2,f)
+    }
+  }
+  
+  override def toString = {
+    val els = depthFirst.view map { case (p,v) =>
+      p.mkString("[",",","]") + " -> "+v
+    }
+    els.mkString("[",", ","]")
+  }
+}
+
+private[antixml] object ZipperHoleMap {
+  def apply[B](items: (ZipperPath,B)*) = {
+    val e: ZipperHoleMap[B] = empty
+    (e /: items) { (mp,i) => mp.updatedDeep(i._1, 0, i._2) }
+  }
+  
+  private [antixml] case class HoleMapNode[+B](value: Option[B], children: Option[ZipperHoleMap[B]])
+  
+  private val unusedLocation = HoleMapNode(None,None)
+  
+  val empty: ZipperHoleMap[Nothing] = new ZipperHoleMap(Map.empty[Int,Nothing])
+}

--- a/src/main/scala/com/codecommit/antixml/ZipperPath.scala
+++ b/src/main/scala/com/codecommit/antixml/ZipperPath.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+package com.codecommit.antixml
+
+import scala.collection.{IndexedSeqOptimized,Seq, LinearSeq}
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.{ArrayBuilder, Builder}
+import scala.collection.immutable.{IndexedSeq}
+
+/** The `IndexedSeq[Int]` implementation used by `Zipper` to represent paths.
+ *
+ * This implementation is optimized specifically for Zipper.  It is backed by
+ * an `Array[Int]` and is both space efficient and fast for reading.  "Modify" operations are `O(n)`, 
+ * in general, but with a small constant factor and are acceptably fast for paths coming from
+ * reasonable XML documents.   `Zipper` doesn't ever modify paths in any case.
+ *
+ * @see [[com.codecommit.antixml.Zipper]]
+ */
+private[antixml] final class ZipperPath private (private val arr: Array[Int]) extends IndexedSeq[Int] with IndexedSeqOptimized[Int, ZipperPath] {
+  override def apply(i: Int) = arr(i)
+  override def length = arr.length
+  override def newBuilder = ZipperPath.newBuilder
+  def valueAt(i: Int): Int = arr(i)
+  
+  //TODO : Needed?  
+  def :+(value: Int): ZipperPath = {
+    val ln = arr.length
+    val a2 = new Array[Int](ln + 1)
+    Array.copy(arr,0,a2,0,ln)
+    a2(ln) = value
+    new ZipperPath(a2)
+  }
+}
+
+
+private[antixml] object ZipperPath {
+  
+  def apply(is: Int*) = fromSeq(is)
+  
+  def fromSeq(s: Seq[Int]): ZipperPath = s match {
+    case iv: ZipperPath => iv
+    case _ => new ZipperPath(toArray(s))
+  }
+  
+  def reversed(s: Seq[Int]): ZipperPath = {
+    val a = toArray(s)
+    val len = a.length
+    val mid = len >> 1
+    for(low <- 0 until mid) {
+      val high = len - low - 1
+      val tmp = a(low)
+      a(low) = a(high)
+      a(high) = tmp
+    }
+    new ZipperPath(a)
+  }
+  
+  private def toArray(s: Seq[Int]): Array[Int] = s match {
+    case _: collection.IndexedSeq[_] => {
+      val len = s.length
+      val a = new Array[Int](len)
+      s.copyToArray(a,0,len)
+      a
+    }
+    case _ => {
+      if (s.isEmpty)
+        new Array[Int](0)
+      else if (s.lengthCompare(1)==0) {
+        val a = new Array[Int](1)
+        a(0) = s.head
+        a
+      } else
+        ((new ArrayBuilder.ofInt) ++= s).result()
+    }
+  }
+    
+  def empty = new ZipperPath(new Array[Int](0))
+  def newBuilder: Builder[Int,ZipperPath] = 
+    new ArrayBuilder.ofInt mapResult (a => if (a.length==0) empty else new ZipperPath(a))
+  
+  object BuilderFactory extends CanBuildFrom[Any,Int,ZipperPath] {
+    def apply() = newBuilder
+    def apply(from: Any) = newBuilder
+  }
+  
+  implicit def canBuildFrom: CanBuildFrom[ZipperPath,Int,ZipperPath] = BuilderFactory
+  
+}
+

--- a/src/main/scala/com/codecommit/antixml/util/vectorCases.scala
+++ b/src/main/scala/com/codecommit/antixml/util/vectorCases.scala
@@ -132,6 +132,8 @@ private[antixml] case object Vector0 extends VectorCase[Nothing] {
   
   override def iterator = Iterator.empty
   
+  override def foreach[U](f: Nothing => U) {}
+  
   def toVector = Vector()
 }
 
@@ -164,6 +166,10 @@ private[antixml] case class Vector1[+A](_1: A) extends VectorCase[A] {
       VectorN(_1 +: that.toVector)
   }
   
+  override def foreach[U](f: A => U) {
+    f(_1)
+  }
+
   // TODO more methods
   
   def toVector = Vector(_1)
@@ -195,6 +201,11 @@ private[antixml] case class Vector2[+A](_1: A, _2: A) extends VectorCase[A] {
       VectorN(Vector(_1, _2) ++ that.toVector)
   }
   
+  override def foreach[U](f: A => U) {
+    f(_1)
+    f(_2)
+  }
+
   // TODO more methods
   
   def toVector = Vector(_1, _2)
@@ -227,6 +238,12 @@ private[antixml] case class Vector3[+A](_1: A, _2: A, _3: A) extends VectorCase[
       VectorN(Vector(_1, _2, _3) ++ that.toVector)
   }
   
+  override def foreach[U](f: A => U) {
+    f(_1) 
+    f(_2)
+    f(_3)
+  }
+
   // TODO more methods
   
   def toVector = Vector(_1, _2, _3)
@@ -260,6 +277,13 @@ private[antixml] case class Vector4[+A](_1: A, _2: A, _3: A, _4: A) extends Vect
       VectorN(Vector(_1, _2, _3, _4) ++ that.toVector)
   }
   
+  override def foreach[U](f: A => U) {
+    f(_1)
+    f(_2)
+    f(_3)
+    f(_4)
+  }
+
   // TODO more methods
   
   def toVector = Vector(_1, _2, _3, _4)
@@ -361,5 +385,7 @@ private[antixml] case class VectorN[+A](vector: Vector[A]) extends VectorCase[A]
   // note: this actually defeats a HotSpot optimization in trivial micro-benchmarks
   override def iterator = vector.iterator
   
+  override def foreach[U](f: A => U) {vector.foreach(f)}
+
   def toVector = vector
 }

--- a/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
@@ -270,6 +270,17 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
       )
     }
   }
+  
+  "Group.matches" should {
+    "never produce false negatives for Strings" in check { (xml: Group[Node]) =>
+      val allElems = xml \\ anyElem
+      allElems forall {e => xml.matches(e.name)} must beTrue
+    }
+    "never produce false negatives for Hashes" in check { (xml: Group[Node]) =>
+      val allElems = xml \\ anyElem
+      allElems forall {e => xml.matches(Group.bloomFilterHash(e.name))} must beTrue
+    }
+  }
 
   "canonicalization" should {
     import Node.CharRegex
@@ -331,5 +342,7 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
   def elem(name: String, children: Node*) = Elem(None, name, Attributes(), Map(), Group(children: _*))
 
   def elem(qname : QName, children: Node*) = Elem(qname.prefix, qname.name, Attributes(), Map(), Group(children: _*))
+  
+  val anyElem: Selector[Elem] = Selector {case e: Elem => e}
 
 }

--- a/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
@@ -223,6 +223,52 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
       
       func(xml) mustEqual xml
     }
+    
+    "foreach should traverse group" in check { (xml: Group[Node]) =>
+      val b = Vector.newBuilder[Node]
+      xml foreach {b += _}
+      val v = b.result
+      val results = for(i <- 0 until xml.length) yield v(i) mustEqual xml(i)
+      (v.length mustEqual xml.length) +: results
+    }
+  }
+  
+  "Group.conditionalFlatMapWithIndex" should {
+    
+    "work with simple replacements" in check { (xml: Group[Node]) =>
+      def f(n: Node, i: Int): Option[Seq[Node]] = n match {
+        case n if (i & 1) == 0 => None
+        case e: Elem => Some(Seq(e.copy(name=e.name.toUpperCase)))
+        case n => None
+      }
+      val cfmwi = xml.conditionalFlatMapWithIndex(f)
+      val equiv = xml.zipWithIndex.flatMap {case (n,i) => f(n,i).getOrElse(Seq(n))}
+      
+      Seq(
+        Vector(cfmwi:_*) mustEqual Vector(equiv:_*),
+        cfmwi.length mustEqual xml.length
+      )
+    }
+    
+    "work with complex replacements" in check { (xml: Group[Node]) =>
+      def f(n: Node, i: Int): Option[Seq[Node]] = n match {
+        case n if (i & 1) == 0 => None
+        case _ if (i & 2) == 0 => Some(Seq())
+        case e: Elem => Some(Seq(e.copy(name=e.name+"MODIFIED"), e, e))
+        case n => Some(Seq(n, n, n))
+      }
+      val cfmwi = xml.conditionalFlatMapWithIndex(f)
+      val equiv = xml.zipWithIndex.flatMap {case (n,i) => f(n,i).getOrElse(Seq(n))}
+      
+      val expectedDels = (xml.length + 2) >>> 2
+      val expectedTripples = (xml.length) >>> 2
+      val expectedLength = xml.length - expectedDels + 2*expectedTripples
+      
+      Seq(
+        Vector(cfmwi:_*) mustEqual Vector(equiv:_*),
+        cfmwi.length mustEqual expectedLength
+      )
+    }
   }
 
   "canonicalization" should {

--- a/src/test/scala/com/codecommit/antixml/PathCreatorSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/PathCreatorSpecs.scala
@@ -36,6 +36,8 @@ import scala.math.Ordering
 
 class PathCreatorSpecs extends SpecificationWithJUnit {
   
+  def vec[A](t: Traversable[A]) = Vector(t.toSeq:_*)
+  
   val s = *
 
   val x0 = fromString("<root0><a0>foo</a0><b0>baz</b0><c0/></root0>")
@@ -54,7 +56,7 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
 
   def ps(pars: (Elem, Int)*) = List(pars.map(_._2): _*) //List(pars.map(ParentLoc.tupled): _*)
   def nl(n: Node, l: Int) = l //WithLoc(n, l)
-  def pv(n: Node, path: Int*) = PathVal(n, Vector(path: _*))
+  def pv(n: Node, path: Int*) = PathVal(n, ZipperPath(path: _*))
   
   val root = Vector(pv(x0,0), pv(x1, 1), pv(x2, 2))
   val directChild = Vector (
@@ -70,12 +72,12 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
   
   "allMaximalChildren" should {
     "stop at the highest match" in {
-      allMaximalChildren(s)(group) mustEqual directChild.sortBy(pathKeys)
+      vec(allMaximalChildren(s)(group)) mustEqual directChild.sortBy(pathKeys)
     }
     
     "find deep matches" in {
       val sel = Selector({case x:Text => x})
-      allMaximalChildren(sel)(group) mustEqual rest.sortBy(pathKeys)      
+      vec(allMaximalChildren(sel)(group)) mustEqual rest.sortBy(pathKeys)      
     }
     
     "find matches at mixed levels" in {
@@ -83,18 +85,18 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
         case e:Elem if e.name == "a0" => e
         case t:Text => t
       })
-      allMaximalChildren(sel)(group) mustEqual (directChild.take(1) ++ rest.drop(1)).sortBy(pathKeys)      
+      vec(allMaximalChildren(sel)(group)) mustEqual (directChild.take(1) ++ rest.drop(1)).sortBy(pathKeys)      
     }
   }
   
   "allMaximal" should {
     "stop at the highest match" in {
-      allMaximal(s)(group) mustEqual root.sortBy(pathKeys)
+      vec(allMaximal(s)(group)) mustEqual root.sortBy(pathKeys)
     }
     
     "find deep matches" in {
       val sel = Selector({case x:Text => x})
-      allMaximal(sel)(group) mustEqual rest.sortBy(pathKeys)      
+      vec(allMaximal(sel)(group)) mustEqual rest.sortBy(pathKeys)      
     }
     
     "find matches at mixed levels" in {
@@ -102,7 +104,7 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
         case e:Elem if e.name == "a0" => e
         case t:Text => t
       })
-      allMaximal(sel)(group) mustEqual (directChild.take(1) ++ rest.drop(1)).sortBy(pathKeys)      
+      vec(allMaximal(sel)(group)) mustEqual (directChild.take(1) ++ rest.drop(1)).sortBy(pathKeys)      
     }
 
     "find matches at mixed levels 2" in {
@@ -110,7 +112,7 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
         case e:Elem if e.name == "root0" || e.name=="a0" || e.name=="a1" => e
         case t:Text => t 
       })
-      allMaximal(sel)(group) mustEqual (root.take(1) ++ directChild.drop(3).take(1) ++ rest.drop(3)).sortBy(pathKeys)      
+      vec(allMaximal(sel)(group)) mustEqual (root.take(1) ++ directChild.drop(3).take(1) ++ rest.drop(3)).sortBy(pathKeys)      
     }
   }
   
@@ -121,36 +123,36 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
     "ignore empty groups" in {
       val empty = Group()
 
-      fromNodes(s)(empty) mustEqual Nil
-      all(s)(empty) mustEqual Nil
-      directChildren(s)(empty) mustEqual Nil
-      allChildren(s)(empty) mustEqual Nil
+      vec(fromNodes(s)(empty)) mustEqual Nil
+      vec(all(s)(empty)) mustEqual Nil
+      vec(directChildren(s)(empty)) mustEqual Nil
+      vec(allChildren(s)(empty)) mustEqual Nil
     }
 
     "take from the root of the nodes" in {
-      fromNodes(s)(group) mustEqual root.sortBy(pathKeys)
+      vec(fromNodes(s)(group)) mustEqual root.sortBy(pathKeys)
     }
 
     "take the children of the root nodes" in {
-      directChildren(s)(group) mustEqual directChild.sortBy(pathKeys)
+      vec(directChildren(s)(group)) mustEqual directChild.sortBy(pathKeys)
     }
 
     "take all the nodes recursively, depth first" in {
-      all(s)(group) mustEqual (root ++ directChild ++ rest).sortBy(pathKeys) 
+      vec(all(s)(group)) mustEqual (root ++ directChild ++ rest).sortBy(pathKeys) 
     }
 
     "take all children nodes recursively, depth first" in {
-      allChildren(s)(group) mustEqual (directChild ++ rest).sortBy(pathKeys)
+      vec(allChildren(s)(group)) mustEqual (directChild ++ rest).sortBy(pathKeys)
     }
 
     "apply selectors at the root level" in {
       val sel = Selector({ case Elem(_, "root1", _, _, _) => elem("selected") })
-      fromNodes(sel)(group) mustEqual Vector(pv(elem("selected"), 1)) 
+      vec(fromNodes(sel)(group)) mustEqual Vector(pv(elem("selected"), 1)) 
     }
 
     "apply selectors to the children of the root" in {
       val sel = Selector({ case Elem(_, "b2", _, _, _) => elem("selected") })
-      directChildren(sel)(group) mustEqual Vector(pv(elem("selected"),2,1))
+      vec(directChildren(sel)(group)) mustEqual Vector(pv(elem("selected"),2,1))
     }
 
     val selDeep = Selector({
@@ -171,11 +173,11 @@ class PathCreatorSpecs extends SpecificationWithJUnit {
     )
 
     "apply selectors recursively" in {
-      all(selDeep)(group) mustEqual (selResRoot ++ selResNoRoot).sortBy(pathKeys)
+      vec(all(selDeep)(group)) mustEqual (selResRoot ++ selResNoRoot).sortBy(pathKeys)
     }
 
     "apply selectors recursively on the children" in {
-      allChildren(selDeep)(group) mustEqual selResNoRoot.sortBy(pathKeys)
+      vec(allChildren(selDeep)(group)) mustEqual selResNoRoot.sortBy(pathKeys)
     }
     
   }

--- a/src/test/scala/com/codecommit/antixml/ZipperHoleMapSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperHoleMapSpecs.scala
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+
+import org.specs2.mutable._
+import org.specs2.ScalaCheck
+import org.specs2.execute.Result
+import org.specs2.matcher.Parameters
+import org.scalacheck.{Arbitrary, Prop, Gen, Choose}
+import Prop._
+import org.specs2.matcher.ScalaCheckMatchers._
+import scala.math.Ordering
+
+class ZipperHoleMapSpecs extends Specification with ScalaCheck {
+  
+  implicit object ZipperPathLexOrder extends Ordering[ZipperPath] {
+    private val delg = Ordering.Iterable[Int]
+    def compare(x: ZipperPath, y: ZipperPath) = delg.compare(x,y)
+  }
+  
+  def p(i: Int*) = ZipperPath(i:_*)
+  
+  def toMap[B](zp: ZipperHoleMap[B]) = Map(zp.depthFirst.toSeq:_*)
+  
+  def extensionsOf(zp: ZipperPath) = new {
+    def in[B](m: Map[ZipperPath,B]): Map[ZipperPath,B] = m.collect {
+      case (k,v) if k.startsWith(zp) && k.length > zp.length => (k.drop(zp.length), v)        
+    }
+  }
+  
+  "ZipperHoleMap.depthFirst" should {
+    "traverse lexicographically" in {
+      forAll(Gen.listOf(saneEntries[Int])) {entries => 
+        val df = ZipperHoleMap(entries:_*).depthFirst
+        val expectedOrder = Map(entries:_*).toSeq.sortBy(_._1)
+        List(df.toSeq:_*) mustEqual List(expectedOrder:_*)
+      }
+    }
+  }
+  
+  "ZipperHoleMap.apply" should {
+    val hm = ZipperHoleMap(p(1)->"a", p(2)->"b", p(1,2,3)->"c", p(3,0,0)->"d")
+    "find leaf values" in {
+      hm(2) mustEqual("b")
+    }
+    "find intermediate values" in {
+      hm(1) mustEqual("a")
+    }
+    "throw on non-existent positions" in {
+      hm(-1) must throwA[Throwable]
+      hm(0) must throwA[Throwable]
+      hm(4) must throwA[Throwable]
+    }
+    "throw on non-valued intermediate nodes" in {
+      hm(3) must throwA[Throwable]
+    }
+    "work with arbitrary entries" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        val r:Result = for(i <- (minSaneLoc - 5) to (maxSaneLoc + 5)) yield {
+          if (m.contains(p(i))) {
+            hm(i) mustEqual m(p(i))
+          } else {
+            hm(i) must throwA[Throwable]
+          }
+        }
+        r
+      }
+    }
+  }
+
+  "ZipperHoleMap.get" should {
+    val hm = ZipperHoleMap(p(1)->"a", p(2)->"b", p(1,2,3)->"c", p(3,0,0)->"d")
+    "find leaf values" in {
+      hm.get(2) mustEqual(Some("b"))
+    }
+    "find intermediate values" in {
+      hm.get(1) mustEqual(Some("a"))
+    }
+    "return None on non-existent positions" in {
+      hm.get(-1) mustEqual None
+      hm.get(0) mustEqual None
+      hm.get(4) mustEqual None
+    }
+    "return None on non-valued intermediate nodes" in {
+      hm.get(3) mustEqual None
+    }
+    "work with arbitrary entries" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        val r:Result = for(i <- (minSaneLoc - 5) to (maxSaneLoc + 5)) yield {
+          hm.get(i) mustEqual m.get(p(i))
+        }
+        r
+      }
+    }
+  }
+  
+  "ZipperHoleMap.contains" should {
+    val hm = ZipperHoleMap(p(1)->"a", p(2)->"b", p(1,2,3)->"c", p(3,0,0)->"d")
+    "find leaf values" in {
+      hm.contains(2) must beTrue
+    }
+    "find intermediate values" in {
+      hm.contains(1) must beTrue
+    }
+    "return None on non-existent positions" in {
+      hm.contains(-1) must beFalse
+      hm.contains(0) must beFalse
+      hm.contains(4) must beFalse
+    }
+    "return None on non-valued intermediate nodes" in {
+      hm.contains(3) must beFalse
+    }
+    "work with arbitrary entries" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        val r:Result = for(i <- (minSaneLoc - 5) to (maxSaneLoc + 5)) yield {
+          hm.contains(i) mustEqual m.contains(p(i))
+        }
+        r
+      }
+    }
+  }
+  
+  "ZipperHoleMap.children" should {
+    val hm = ZipperHoleMap(p(1)->"a", p(2)->"b", p(1,1)->"c", p(1,2,3)->"d", p(1,2,4)->"e", p(3,0,0)->"f")
+    "throw on leaf values" in {
+      hm.children(2) must throwA[Throwable]
+    }
+    "find intermediate valued nodes" in {
+      val c = hm.children(1) 
+      toMap(c) mustEqual Map(p(1)->"c",p(2,3)->"d",p(2,4)->"e")
+    }
+    "find intermediate non-valued nodes" in {
+      val c = hm.children(3) 
+      toMap(c) mustEqual Map(p(0,0)->"f")
+    }
+    "throw on non-existent positions" in {
+      hm.children(-1) must throwA[Throwable]
+      hm.children(0) must throwA[Throwable]
+      hm.children(4) must throwA[Throwable]
+    }
+    "work with arbitrary entries" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        val r:Result = for(i <- (minSaneLoc - 5) to (maxSaneLoc + 5)) yield {
+          val expect = extensionsOf(p(i)).in(m)
+          if (expect.isEmpty)
+            hm.children(i) must throwA[Throwable]
+          else
+            toMap(hm.children(i)) mustEqual expect
+        }
+        r
+      }
+    }
+  }
+  
+  "ZipperHoleMap.hasChildrenAt" should {
+    val hm = ZipperHoleMap(p(1)->"a", p(2)->"b", p(1,1)->"c", p(1,2,3)->"d", p(1,2,4)->"e", p(3,0,0)->"f")
+    "return false on leaf values" in {
+      hm.hasChildrenAt(2) must beFalse
+    }
+    "return true on intermediate valued nodes" in {
+      hm.hasChildrenAt(1) must beTrue
+    }
+    "return true on intermediate non-valued nodes" in {
+      hm.hasChildrenAt(3) must beTrue
+    }
+    "return false on non-existent positions" in {
+      hm.hasChildrenAt(-1) must beFalse
+      hm.hasChildrenAt(0) must beFalse
+      hm.hasChildrenAt(4) must beFalse
+    }
+    "work with arbitrary entries" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        val r:Result = for(i <- (minSaneLoc - 5) to (maxSaneLoc + 5)) yield {
+          val expect = extensionsOf(p(i)).in(m)
+          hm.hasChildrenAt(i) mustEqual (!expect.isEmpty)
+        }
+        r
+      }
+    }
+  }
+  
+  "ZipperHoleMap.getDeep" should {
+    val hm = ZipperHoleMap(p(1)->"a", p(2)->"b", p(1,2)->"c", p(1,2,3)->"d", p(1,2,4)->"e", p(3,0,0)->"f")
+    val hmMap = toMap(hm)
+    "find leaf values" in Seq(
+      hm.getDeep(p(2)) mustEqual Some("b"),
+      hm.getDeep(p(1,2,3)) mustEqual Some("d"),
+      hm.getDeep(p(1,2,4)) mustEqual Some("e"),
+      hm.getDeep(p(3,0,0)) mustEqual Some("f")
+    )
+    
+    "find intermediate valued nodes" in Seq(
+      hm.getDeep(p(1)) mustEqual Some("a"),
+      hm.getDeep(p(1,2)) mustEqual Some("c")
+    )
+    "return None on intermediate non-valued nodes" in Seq(
+      hm.getDeep(p(3)) mustEqual None,
+      hm.getDeep(p(3,0)) mustEqual None
+    )
+    "return None on non-existent positions" in Seq(
+      hm.getDeep(p(-1)) mustEqual None,
+      hm.getDeep(p(-1,0)) mustEqual None,
+      hm.getDeep(p(0)) mustEqual None,
+      hm.getDeep(p(0,1,2,3)) mustEqual None,
+      hm.getDeep(p(1,2,3,4)) mustEqual None,
+      hm.getDeep(p(4)) mustEqual None,
+      hm.getDeep(p(4,4,4,4,4)) mustEqual None
+    )
+    "work with arbitrary entries and paths" in {
+      forAll(Gen.listOf(saneEntries[Int]), sanePaths) { (entries,path) =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        hm.getDeep(path) mustEqual m.get(path)
+      }
+    }
+    "find all of its arbitrary entries" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        val r:Result = if (!entries.isEmpty) { 
+          for(path <- m.keys.toSeq) yield hm.getDeep(path) mustEqual Some(m(path))
+        } else {
+          //specs chokes on an empty Result sequence, so do something else for the empty case
+          hm.getDeep(p(0)) mustEqual None
+        }
+        r
+      }
+    }
+  }
+  
+  "ZipperHoleMap.updatedDeep" should {
+    val hm = ZipperHoleMap(p(1)->"a", p(2)->"b", p(1,2)->"c", p(1,2,3)->"d", p(1,2,4)->"e", p(3,0,0)->"f")
+    val hmMap = toMap(hm)
+    "replace leaf values" in Seq(
+      toMap(hm.updatedDeep(p(2),"XYZ")) mustEqual hmMap.updated(p(2),"XYZ"),
+      toMap(hm.updatedDeep(p(1,2,3),"123")) mustEqual hmMap.updated(p(1,2,3),"123")
+    )
+    "set intermediate valued nodes" in Seq(
+      toMap(hm.updatedDeep(p(1),"IM1")) mustEqual hmMap.updated(p(1),"IM1"),
+      toMap(hm.updatedDeep(p(1,2),"IM12")) mustEqual hmMap.updated(p(1,2),"IM12")
+    )
+    "set intermediate non-valued nodes" in Seq(
+      toMap(hm.updatedDeep(p(3),"NV3")) mustEqual hmMap.updated(p(3),"NV3"),
+      toMap(hm.updatedDeep(p(3,0),"NV30")) mustEqual hmMap.updated(p(3,0),"NV30")
+    )
+    "set non-existent positions" in Seq(
+      toMap(hm.updatedDeep(p(-1),"QQQ")) mustEqual hmMap.updated(p(-1),"QQQ"),
+      toMap(hm.updatedDeep(p(-1,0),"QQQ")) mustEqual hmMap.updated(p(-1,0),"QQQ"),
+      toMap(hm.updatedDeep(p(0),"QQQ")) mustEqual hmMap.updated(p(0),"QQQ"),
+      toMap(hm.updatedDeep(p(0,1,2,3),"QQQ")) mustEqual hmMap.updated(p(0,1,2,3),"QQQ"),
+      toMap(hm.updatedDeep(p(1,2,3,4),"QQQ")) mustEqual hmMap.updated(p(1,2,3,4),"QQQ"),
+      toMap(hm.updatedDeep(p(4),"QQQ")) mustEqual hmMap.updated(p(4),"QQQ"),
+      toMap(hm.updatedDeep(p(4,4,4,4),"QQQ")) mustEqual hmMap.updated(p(4,4,4,4),"QQQ"),
+      toMap(hm.updatedDeep(p(2,99),"QQQ")) mustEqual hmMap.updated(p(2,99),"QQQ")
+    )
+    "work with arbitrary entries, paths, and values" in {
+      forAll(Gen.listOf(saneEntries[Int]), sanePaths, Arbitrary.arbInt.arbitrary) { (entries,path,value) =>
+        val hm = ZipperHoleMap(entries:_*)
+        val m = Map(entries:_*)
+        toMap(hm.updatedDeep(path,value)) mustEqual m.updated(path,value)
+      }
+    }
+  }
+  
+  "ZipperHoleMap.toString" should {
+    "be non-empty" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        val s = hm.toString
+        s.length must beGreaterThan(0)
+      }
+    }
+  }
+  
+  "ZipperHoleMap companion" should {
+    "have an empty empty" in {
+      val hm:ZipperHoleMap[Int] = ZipperHoleMap.empty
+      toMap(hm).size mustEqual 0
+    }
+    "build ZipperHoleMaps using apply" in {
+      forAll(Gen.listOf(saneEntries[Int])) { entries =>
+        val hm = ZipperHoleMap(entries:_*)
+        toMap(hm) mustEqual Map(entries:_*)
+      }
+    }
+  }
+  
+  def saneEntries[B](implicit valGen: Arbitrary[B]): Gen[(ZipperPath, B)] = for {
+    path <- sanePaths
+    value <- valGen.arbitrary
+  } yield (path,value)
+  
+  def sanePaths: Gen[ZipperPath] = for {
+    items <- Gen.listOf(saneLocations)
+    head <- saneLocations
+  } yield ZipperPath((head :: items):_*)
+  
+  //Using a small range to ensure some overlapping prefixes
+  private final val minSaneLoc = 0
+  private final val maxSaneLoc = 10
+  def saneLocations: Gen[Int] = Choose.chooseInt.choose(minSaneLoc,maxSaneLoc) 
+}

--- a/src/test/scala/com/codecommit/antixml/ZipperPathSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperPathSpecs.scala
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+
+import org.specs2.mutable._
+import org.specs2.ScalaCheck
+import org.specs2.matcher.Parameters
+import org.scalacheck.{Arbitrary, Prop}
+import Prop._
+import org.specs2.matcher.ScalaCheckMatchers._
+
+class ZipperPathSpecs extends Specification with ScalaCheck {
+  import math._
+  
+  //Shaemelessly stolen from VectorCaseSpecs
+  
+  val emptyPath = ZipperPath()
+  
+  "ZipperPath companion" should {
+
+    "build using apply" in check { (items: List[Int]) =>
+      val zp = ZipperPath(items:_*)
+      items mustEqual List(zp:_*)
+    }
+
+    "build from a ZipperPath using fromSeq" in check { (items: ZipperPath) =>
+      val zp = ZipperPath.fromSeq(items)
+      List(items:_*) mustEqual List(zp:_*)
+    }
+
+    "build from an IndexedSeq using fromSeq" in check { (items: Vector[Int]) =>
+      val zp = ZipperPath.fromSeq(items)
+      List(items:_*) mustEqual List(zp:_*)
+    }
+
+    "build from a LinearSeq using fromSeq" in check { (items: List[Int]) =>
+      val zp = ZipperPath.fromSeq(items)
+      List(items:_*) mustEqual List(zp:_*)
+    }
+
+    "build from a ZipperPath using reversed" in check { (items: ZipperPath) =>
+      val zp = ZipperPath.reversed(items)
+      List(items:_*).reverse mustEqual List(zp:_*)
+    }
+
+    "build from an IndexedSeq using reversed" in check { (items: Vector[Int]) =>
+      val zp = ZipperPath.reversed(items)
+      List(items:_*).reverse mustEqual List(zp:_*)
+    }
+
+    "build from a LinearSeq using reversed" in check { (items: List[Int]) =>
+      val zp = ZipperPath.reversed(items)
+      List(items:_*).reverse mustEqual List(zp:_*)
+    }
+    
+    "should have an empty empty" in {
+      ZipperPath.empty.length mustEqual 0
+    }
+
+    "should produce builders" in check { (items: List[Int]) =>
+      val zp = (ZipperPath.newBuilder ++= items).result
+      List(items:_*) mustEqual List(zp:_*)
+    }
+
+  }
+  
+  "ZipperPath" should {
+    "store a single element" in {
+      val v2 = emptyPath :+ 42
+      v2(0) mustEqual 42
+    }
+    
+    "implement +:" in check { (zp: ZipperPath, i: Int) =>
+      val zp2 = i +: zp
+      zp2.length mustEqual (zp.length + 1)
+      zp2.head mustEqual i
+      zp.zipWithIndex forall {
+        case (x, i) => zp2(i + 1) mustEqual x
+      }
+    }
+    
+    "implement :+" in check { (zp: ZipperPath, i: Int) =>
+      val zp2 = zp :+ i
+      zp2.length mustEqual (zp.length + 1)
+      zp2.last mustEqual i
+      zp.zipWithIndex forall {
+        case (x, i) => zp2(i) mustEqual x
+      }
+    }
+    
+    "implement ++" in check { (zp1: ZipperPath, zp2: ZipperPath) =>
+      val result1 = zp1 ++ zp2
+      val result2 = zp2 ++ zp1
+      
+      result1.length mustEqual (zp1.length + zp2.length)
+      result1.length mustEqual result2.length
+      
+      zp1.zipWithIndex forall {
+        case (x, i) => {
+          result1(i) mustEqual x
+          result2(i + zp2.length) mustEqual x
+        }
+      }
+      
+      zp2.zipWithIndex forall {
+        case (x, i) => {
+          result2(i) mustEqual x
+          result1(i + zp1.length) mustEqual x
+        }
+      }
+    }
+    
+    "implement length" in check { list: List[Int] =>
+      val zp = list.foldLeft(ZipperPath()) { _ :+ _ }
+      zp.length === list.length
+    }
+    
+    "replace single element" in check { (zp: ZipperPath, i: Int) =>
+      (zp.nonEmpty && i > Int.MinValue) ==> {
+        val idx = abs(i) % zp.length
+        val newVectorCase = zp.updated(idx, "test").updated(idx, "newTest")
+        newVectorCase(idx) mustEqual "newTest"
+      }
+    }
+    "fail on apply out-of-bounds" in check { (zp: ZipperPath, i: Int) =>
+      !((0 until zp.length) contains i) ==> { zp(i) must throwA[Throwable] }
+    }
+    
+    "store multiple elements in order" in check { list: List[Int] =>
+      val newVectorCase = list.foldLeft(emptyPath) { _ :+ _ }
+      val res = for (i <- 0 until list.length) yield newVectorCase(i) == list(i)
+
+      res must not contain (false)
+    }
+
+    "store lots of elements" in {
+      val LENGTH = 100000
+      val emptyPath = (0 until LENGTH).foldLeft(ZipperPath()) { _ :+ _ }
+      
+      emptyPath.length mustEqual LENGTH
+      ((i:Int) => emptyPath(i) mustEqual i).forall(0 until LENGTH)
+    }
+    
+    "maintain both old and new versions after conj" in check { zp: ZipperPath =>
+      val zp2 = zp :+ 42
+      for (i <- 0 until zp.length) {
+        zp2(i) aka ("Index " + i + " in derivative") mustEqual zp(i) aka ("Index " + i + " in origin")
+      }
+      zp2.last mustEqual 42
+    }.set(maxSize -> 3000, minTestsOk -> 1000, workers -> numProcessors)
+
+    "maintain both old and new versions after update" in check { (zp: ZipperPath, i: Int) =>
+      (!zp.isEmpty && i > Int.MinValue) ==> {
+        val idx = abs(i) % zp.length
+        val zp2 = zp.updated(idx, 42)
+        for (i <- 0 until zp.length if i != idx) {
+          zp2(i) aka ("Index " + i + " in derivative") mustEqual zp(i) aka ("Index " + i + " in origin")
+        }
+        zp2(idx) mustEqual 42
+      }
+    }
+    
+    "implement drop matching Vector semantics (in general case)" in check { (zp: ZipperPath, len: Int) =>
+      toVector(zp drop len) mustEqual (toVector(zp) drop len)
+    }
+    
+    "implement dropRight matching Vector semantics" in check { (zp: ZipperPath, len: Int) =>
+      //IndexedSeqOptimized doesn't match Vector for negative lengths
+      val l2 = max(0,len)
+      toVector(zp dropRight l2) mustEqual (toVector(zp) dropRight l2)
+    }
+    
+    "implement filter" in check { (zp: ZipperPath, f: (Int)=>Boolean) =>
+      val filtered = zp filter f
+
+      var back = filtered forall f
+      for (e <- zp) {
+        if (f(e)) {
+          back &&= filtered.contains(e)
+        }
+      }
+      back
+    }
+    
+    "implement foldLeft" in check { list: List[Int] =>
+      val zp = list.foldLeft(ZipperPath()) { _ :+ _ }
+      zp.foldLeft(0) { _ + _ } === list.foldLeft(0) { _ + _ }
+    }
+    
+    "implement foreach" in check { zp: ZipperPath =>
+      val b = Vector.newBuilder[Int]
+      for(i <- zp)
+        b += i
+      val v = b.result()
+      v mustEqual zp
+    }
+    
+    "implement forall" in check { (zp: ZipperPath, f: (Int)=>Boolean) =>
+      val bool = zp forall f
+      
+      var back = true
+      for (e <- zp) {
+        back &&= f(e)
+      }
+      
+      (back && bool) || (!back && !bool)
+    }
+    
+    "implement flatMap" in check { (zp: ZipperPath, f: (Int)=>ZipperPath) =>
+      val mapped = zp flatMap f
+      
+      var back = true
+      
+      var i = 0
+      var n = 0
+      
+      while (i < zp.length) {
+        val res = f(zp(i))
+        
+        var inner = 0
+        while (inner < res.length) {
+          back &&= mapped(n) == res(inner)
+          
+          inner += 1
+          n += 1
+        }
+        
+        i += 1
+      }
+
+      back
+    }
+    
+    "implement init matching Vector semantics" in check { zp: ZipperPath =>
+      !zp.isEmpty ==> {
+        toVector(zp.init) mustEqual toVector(zp).init
+      }
+    }
+    
+    "implement map" in check { (zp: ZipperPath, f: (Int)=>Int) =>
+      val mapped = zp map f
+      
+      var back = zp.length == mapped.length
+      for (i <- 0 until zp.length) {
+        back &&= mapped(i) == f(zp(i))
+      }
+      back
+    }
+    
+    "implement reverse" in check { v: ZipperPath =>
+      val reversed = v.reverse
+      
+      var back = v.length == reversed.length
+      for (i <- 0 until v.length) {
+        back &&= reversed(i) == v(v.length - i - 1)
+      }
+      back
+    }
+    
+    "append to reverse" in check { (v: ZipperPath, n: Int) =>
+      val rev = v.reverse
+      val add = rev :+ n
+      
+      var back = add.length == rev.length + 1
+      for (i <- 0 until rev.length) {
+        back &&= add(i) == rev(i)
+      }
+      back && add(rev.length) === n
+    }
+    
+    "map on reverse" in check { (v: ZipperPath, f: (Int)=>Int) =>
+      val rev = v.reverse
+      val mapped = rev map f
+      
+      var back = mapped.length == rev.length
+      for (i <- 0 until rev.length) {
+        back &&= mapped(i) == f(rev(i))
+      }
+      back
+    }
+    
+    /* "implement slice matching Vector semantics" in check { (zp: ZipperPath, from: Int, until: Int) =>
+      // skip("Vector slice semantics are inconsistent with Traversable")
+      zp.slice(from, until).toVector mustEqual zp.toVector.slice(from, until)
+    } */
+    
+    "implement splitAt matching Vector semantics" in check { (zp: ZipperPath, i: Int) =>
+      val (left, right) = zp splitAt i
+      val (expectLeft, expectRight) = toVector(zp) splitAt i
+      
+      toVector(left) mustEqual expectLeft
+      toVector(right) mustEqual expectRight
+    }
+    
+    "implement tail matching Vector semantics" in check { zp: ZipperPath =>
+      !zp.isEmpty ==> {
+        toVector(zp.tail) mustEqual toVector(zp).tail
+      }
+    }
+    
+    "implement take matching Vector semantics" in check { (zp: ZipperPath, len: Int) =>
+      toVector(zp take len) mustEqual (toVector(zp) take len)
+    }
+    
+    "implement takeRight matching Vector semantics" in check { (zp: ZipperPath, len: Int) =>
+      //scala.collection.IndexedSeqOptimized differs from Vector on negative lengths
+      val l2 = max(0,len)
+      toVector(zp takeRight l2) mustEqual (toVector(zp) takeRight l2)
+    }
+    
+    "implement zip" in check { (first: ZipperPath, second: ZipperPath) =>
+      val zip = first zip second
+      
+      var back = zip.length == min(first.length, second.length)
+      for (i <- 0 until zip.length) {
+        var (left, right) = zip(i)
+        back &&= (left == first(i) && right == second(i))
+      }
+      back
+    }
+    
+    "implement zipWithIndex" in check { zp: ZipperPath =>
+      val zip = zp.zipWithIndex
+      
+      var back = zip.length == zp.length
+      for (i <- 0 until zip.length) {
+        val (elem, index) = zip(i)
+        back &&= (index == i && elem == zp(i))
+      }
+      back
+    }
+    
+    "implement equals" >> {
+      "1." in check { list: List[Int] => 
+        val zpA = list.foldLeft(ZipperPath()) { _ :+ _ }
+        val zpB = list.foldLeft(ZipperPath()) { _ :+ _ }
+        zpA === zpB
+      }
+      "2." in check { (zpA: ZipperPath, zpB: ZipperPath) =>
+        zpA.length != zpB.length ==> (zpA != zpB)
+      }
+      "3." in check { (listA: List[Int], listB: List[Int]) =>
+        val zpA = listA.foldLeft(ZipperPath()) { _ :+ _ }
+        val zpB = listB.foldLeft(ZipperPath()) { _ :+ _ }
+        
+        listA != listB ==> (zpA != zpB)
+      }      
+      "4." in check { (zp: ZipperPath, data: Int) => zp !== data }
+    }
+    
+    "implement hashCode" in check { list: List[Int] =>
+      val zpA = list.foldLeft(ZipperPath()) { _ :+ _ }
+      val zpB = list.foldLeft(ZipperPath()) { _ :+ _ }
+      zpA.hashCode === zpB.hashCode
+    }
+  }
+  
+  implicit def arbitraryZipperPath: Arbitrary[ZipperPath] = {
+    Arbitrary(for {
+      data <- Arbitrary.arbitrary[List[Int]]
+    } yield ZipperPath.fromSeq(data))
+  }
+  implicit def arbitraryVector[A](implicit arb: Arbitrary[A]): Arbitrary[Vector[A]] = {
+    Arbitrary(for {
+      data <- Arbitrary.arbitrary[List[A]]
+    } yield Vector(data:_*))
+  }
+
+  def toVector(zp: ZipperPath): Vector[Int] = {
+    (Vector[Int]() /: (0 until zp.length)) { (v,i) =>
+      v :+ zp(i)
+    }
+  }
+  
+  val numProcessors = Runtime.getRuntime.availableProcessors
+  implicit val params: Parameters = set(workers -> numProcessors)
+}
+
+  

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -936,6 +936,25 @@ class ZipperSpecs extends SpecificationWithJUnit with ScalaCheck  with XMLGenera
     }
   }
   
+  "Zipper.flatMap" should {
+    "increase update times front to back" in {
+      val xml = <top><a><b /></a></top>.convert
+      val z = xml \\ *
+      
+      //Conflicting updates.  First node has latest update time.
+      val z1 = z.updated(1,elem("b2"))  
+      val z2 = z1.updated(0,elem("a",elem("c")))
+      
+      //Apply a flatMap, which will make the second node have the latest update time
+      val z3 = z2 flatMap {n => Seq(n)}
+ 
+      z2.unselect mustEqual <top><a><c /></a></top>.convert.toGroup
+      z3.unselect mustEqual <top><a><b2 /></a></top>.convert.toGroup
+
+    }
+  }
+  
+  
   def validate[Expected] = new {
     def apply[A](a: A)(implicit evidence: A =:= Expected) = evidence must not beNull
   }

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -916,6 +916,26 @@ class ZipperSpecs extends SpecificationWithJUnit with ScalaCheck  with XMLGenera
     }
   }
 
+  "Zipper.unselect" should {
+    "only modify the update times of nodes that receive updates" in {
+      val xml = <top><a><b /></a></top>.convert
+      val z = xml \\ *
+      
+      //Conflicting updates.  Second node has latest update time.
+      val z1 = z.updated(0,elem("a",elem("c")))
+      val z2 = z1.updated(1,elem("b2"))  
+      
+      //Make an update to the first node only through a child zipper
+      val zInner = z2 select 'a
+      val zInner1 = zInner.updated(0, zInner(0).asInstanceOf[Elem].copy(name="A"))
+      val z3 = zInner1.unselect
+ 
+      z2.unselect mustEqual <top><a><b2 /></a></top>.convert.toGroup
+      z3.unselect mustEqual <top><A><c /></A></top>.convert.toGroup
+
+    }
+  }
+  
   def validate[Expected] = new {
     def apply[A](a: A)(implicit evidence: A =:= Expected) = evidence must not beNull
   }

--- a/src/test/scala/com/codecommit/antixml/performance/JavaNodeSeqWithIndexedSeq.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/JavaNodeSeqWithIndexedSeq.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+package performance
+
+import org.w3c.dom
+import scala.collection.IndexedSeqOptimized
+
+sealed trait JavaNodeSeqWithIndexedSeq extends scala.collection.IndexedSeq[dom.Node] 
+      with dom.NodeList 
+      with IndexedSeqOptimized[dom.Node,scala.collection.IndexedSeq[dom.Node]] {
+        
+  /** Simulated one-level select */
+  def \(name: String): JavaNodeSeqWithIndexedSeq = {
+    val b = JavaNodeSeqWithIndexedSeq.newBuilder
+    for(node <- this; node2 <- JavaNodeSeqWithIndexedSeq.wrap(node.getChildNodes)) node2 match {
+      case e: dom.Element => {
+        if (simpleNameOf(e) == name)
+          b += e
+      }
+      case _ => ()
+    }
+    b.result
+  }
+}
+
+object JavaNodeSeqWithIndexedSeq {
+  def wrap(s: scala.collection.IndexedSeq[dom.Node]) = s match {
+    case jnswis: JavaNodeSeqWithIndexedSeq => jnswis
+    case _ =>  new JavaNodeSeqWithIndexedSeq {
+      override def apply(i: Int) = s(i)
+      override def length = s.length
+      override def getLength = s.length
+      override def item(i: Int) = s(i)
+    }
+  }
+  def wrap(nl: dom.NodeList) = nl match {
+    case jnswis: JavaNodeSeqWithIndexedSeq => jnswis
+    case _=> new JavaNodeSeqWithIndexedSeq {
+      override def apply(i: Int) = nl.item(i)
+      override def length = nl.getLength
+      override def getLength = nl.getLength
+      override def item(i: Int) = nl.item(i)
+    }
+  }
+  
+  def newBuilder = Array.newBuilder[dom.Node] mapResult {wrap(_)}
+  
+  //Use this instead of `wrap` to force a lazy NodeList to be realized.
+  def copy(nl: dom.NodeList) = {
+    val b = newBuilder
+    for(i <- 0 until nl.getLength)
+      b += nl.item(i)
+    b.result
+  }
+}

--- a/src/test/scala/com/codecommit/antixml/performance/Performance.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/Performance.scala
@@ -59,7 +59,8 @@ object Performance {
       ShallowZipperOps,
       DeepZipperOps,
       HugeZipperOps,
-      HugeDeadZipperOps
+      HugeDeadZipperOps,
+      HugeZipperWithEmptyHolesOps
       )
   
   /* === Load trials === */
@@ -246,4 +247,14 @@ object Performance {
     override def unselectCount = 0
   }
   
+  object HugeZipperWithEmptyHolesOps extends Trial('zipperHugeFiltered, "operations on a BIG zipper that was partially filtered") with ZipperOpsTrial {
+    override val classifiers = Set('zipperOps, 'shallow, 'small)
+    override def xmlResource = getClass.getResource("/spending.xml")
+    override def createZipper(xml: Elem) = {
+      val z = xml \\ anyElem
+      z.slice(z.length/4, z.length/4 + z.length/2)
+    }
+    
+    override def unselectCount = 1
+  }
 }

--- a/src/test/scala/com/codecommit/antixml/performance/Performance.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/Performance.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+package performance
+
+object Performance {
+  
+  def main(args: Array[String]) {
+    new PerformanceRunner(trials).run(args)
+  }
+
+  val trials = List(
+      LoadingXmlSmall,
+      LoadingXmlLarge,
+      
+      ShallowSelectionSmall,
+      DeepSelectionSmall,
+      ShallowSelectionSmallCold,
+      DeepSelectionSmallCold,
+      DeepSelectionOnceSmallCold,
+      ShallowSelectionLarge,
+      DeepSelectionLarge,
+      
+      ShallowModifyFewSmall,
+      ShallowModifyFewSmallSelectionTime,
+      ShallowModifyManySmall,
+      ShallowModifyManySmallSelectionTime,
+      DeepModifyFewSmall,
+      DeepModifyFewSmallSelectionTime,
+      DeepModifyManySmall,
+      DeepModifyManySmallSelectionTime,
+
+      ShallowZipperOps,
+      DeepZipperOps,
+      HugeZipperOps,
+      HugeDeadZipperOps
+      )
+  
+  /* === Load trials === */
+  
+  object LoadingXmlSmall extends Trial('loadSmall, "Loading a 7 MB XML file") with LoadTrial {
+    override val sizeDescription = "7 MB"
+    override val classifiers = Set('load, 'small)
+    override def xmlResource = getClass.getResource("/spending.xml")
+  }
+
+  object LoadingXmlLarge extends Trial('loadLarge, "Loading a 30 MB XML file") with LoadTrial {
+    override val warmUps = 5
+    override val sizeDescription = "30 MB"
+    override val runLevel = 2
+    override val classifiers = Set('load, 'large)
+    override def xmlResource = getClass.getResource("/discogs_20110201_labels.xml")
+  }
+
+  /* === Selection trials === */
+  
+  object ShallowSelectionSmall extends Trial('shallowSelectSmall, "Shallow selection in a 7 MB tree") with WarmShallowSelectionTrial {
+    override val classifiers = Set('select, 'small, 'shallow)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List(List("result","doc","MajorFundingAgency2"), List("foo","bar", "MajorFundingAgency2"))
+  }
+  
+
+  object DeepSelectionSmall extends Trial('deepSelectSmall, "Deep selection in a 7 MB tree") with WarmDeepSelectionTrial {
+    override val classifiers = Set('select, 'small, 'deep)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List("MajorFundingAgency2","fubar")
+  }
+
+  object ShallowSelectionSmallCold extends Trial('shallowSelectSmallCold, "Shallow selection in a cold 7 MB tree") with ColdShallowSelectionTrial {
+    override val runLevel = 1
+    override val classifiers = Set('select, 'small, 'shallow, 'cold)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List(List("result","doc","MajorFundingAgency2"), List("foo","bar", "MajorFundingAgency2"))
+  }
+
+  object DeepSelectionSmallCold extends Trial('deepSelectSmallCold, "Deep selection in a cold 7 MB tree") with ColdDeepSelectionTrial {
+    override val runLevel = 1
+    override val classifiers = Set('select, 'small, 'deep, 'cold)
+
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List("MajorFundingAgency2","fubar")
+
+  }
+  
+  /** This is similar to `DeepSelectionSmallCold` except it only does a single deep select, which is useful for calculating the one-time cost of the bloom filter. */
+  object DeepSelectionOnceSmallCold extends Trial('deepSelectOnceSmallCold, "One-time deep selection in a cold 7MB tree") with ColdDeepSelectionTrial {
+    override val runLevel = 1
+    override val classifiers = Set('select, 'small, 'deep, 'cold)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List("MajorFundingAgency2")
+  }
+
+  object ShallowSelectionLarge extends Trial('shallowSelectLarge, "Shallow selection in a 30 MB tree") with WarmShallowSelectionTrial {
+    override val runLevel = 2
+    override val classifiers = Set('select, 'shallow, 'large)
+
+    override val xmlResource = getClass.getResource("/discogs_20110201_labels.xml")
+    override val selections = List(List("label","sublabels","label"), List("foo","bar", "label"))    
+  }
+
+  object DeepSelectionLarge extends Trial('deepSelectLarge, "Deep selection in a 30 MB tree") with WarmDeepSelectionTrial {
+    override val runLevel = 2
+    override val classifiers = Set('select, 'deep, 'large)
+
+    override val xmlResource = getClass.getResource("/discogs_20110201_labels.xml")
+    override val selections = List("sublabels","fubar")
+  }
+  
+  /* === Modify Trials === */
+  
+  object ShallowModifyFewSmall extends Trial('shallowModifyFewSmall, "shallow modify a few elements of a 7 MB tree") with ShallowModifyTrial {
+    override val classifiers = Set('modify, 'small, 'shallow)
+
+    val xmlResource = getClass.getResource("/spending.xml")
+    val selection = List("result","doc","MajorFundingAgency2")
+    val attributeToSet = ("WasModified","true")
+  }
+  
+  object ShallowModifyFewSmallSelectionTime extends Trial('shallowModifyFewSmallSel, "selection-only times for [shallowModifyFewSmall]") with WarmShallowSelectionTrial {
+    override val runLevel = 1
+    override val classifiers = Set('modify, 'small, 'shallow)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List(List("result","doc","MajorFundingAgency2"))
+  }
+  
+  object ShallowModifyManySmall extends Trial('shallowModifyManySmall, "shallow modify many elements of a 7 MB tree") with ShallowModifyTrial {
+    override val classifiers = Set('modify, 'small, 'shallow)
+
+    val xmlResource = getClass.getResource("/spending.xml")
+    val selection = List("result","doc","FiscalYear")
+    val attributeToSet = ("WasModified","true")
+  }
+
+  object ShallowModifyManySmallSelectionTime extends Trial('shallowModifyManySmallSel, "selection-only times for [shallowModifyManySmall]") with WarmShallowSelectionTrial {
+    override val runLevel = 1
+    override val classifiers = Set('modify, 'small, 'shallow)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List(List("result","doc","FiscalYear"))
+  }
+
+
+  object DeepModifyFewSmall extends Trial('deepModifyFewSmall, "deep modify a few elements of a 7 MB tree") with DeepModifyTrial {
+    override val classifiers = Set('modify, 'small, 'deep)
+
+    val xmlResource = getClass.getResource("/spending.xml")
+    val selection = "MajorFundingAgency2"
+    val attributeToSet = ("WasModified","true")
+  }
+    
+  /** Used to measure the selection-only time for the nodes modified DeepModifySmall */
+  object DeepModifyFewSmallSelectionTime extends Trial('deepModifyFewSmallSel, "Selection-only times for [deepModifyFewSmall]") with WarmDeepSelectionTrial {
+    override val runLevel = 1
+    override val classifiers = Set('modify, 'small, 'deep)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List("MajorFundingAgency2")
+  }
+  
+  object DeepModifyManySmall extends Trial('deepModifyManySmall, "deep modification of many elements of a 7 MB tree") with DeepModifyTrial {
+    override val classifiers = Set('modify, 'small, 'deep)
+
+    val xmlResource = getClass.getResource("/spending.xml")
+    val selection = "FiscalYear"
+    val attributeToSet = ("WasModified","true")
+
+    //Hack to force javaXml to use only one warmUp and one run because it's sooooooo slow.     
+    override def create = new ModifyInstance {
+      override def warmUps(impl: AnyImpl) = if (impl == javaXml) 1 else super.warmUps(impl)
+      override def runs(impl: AnyImpl) = if (impl == javaXml) 1 else super.runs(impl)
+    }
+  }
+    
+  /** Used to measure the selection-only time for the nodes modified DeepModifySmall */
+  object DeepModifyManySmallSelectionTime extends Trial('deepModifyManySmallSel, "Selection-only times for [deepModifyManySmall]") with WarmDeepSelectionTrial {
+    override val runLevel = 1
+    override val classifiers = Set('modify, 'small, 'deep)
+    
+    override val xmlResource = getClass.getResource("/spending.xml")
+    override val selections = List("FiscalYear")
+  }
+  
+  /* === Zipper Method Trials === */
+  
+  object ShallowZipperOps extends Trial('zipperShallow, "operations on zipper from a 7 MB tree, shallow selected") with ZipperOpsTrial {
+    override val classifiers = Set('zipperOps, 'shallow, 'small)
+    override def xmlResource = getClass.getResource("/spending.xml")
+    override def createZipper(xml: Elem) = xml \ "result" \ "doc" \ "AgencyID"
+    override def unselectCount = 3    
+    
+    override def nodePred(n: Node): Boolean = (n.asInstanceOf[Elem].children(0).asInstanceOf[Text].text.length & 1) == 0
+  }
+  
+  object DeepZipperOps extends Trial('zipperDeep, "operations on zipper from a 7 MB tree, deep selected") with ZipperOpsTrial {
+    override val classifiers = Set('zipperOps, 'shallow, 'small)
+    override def xmlResource = getClass.getResource("/spending.xml")
+    override def createZipper(xml: Elem) = xml \\ "AgencyID"
+    override def unselectCount = 1
+    
+    override def nodePred(n: Node): Boolean = (n.asInstanceOf[Elem].children(0).asInstanceOf[Text].text.length & 1) == 0
+  }
+
+  object HugeZipperOps extends Trial('zipperHuge, "operations on a BIG zipper from a 7 MB tree") with ZipperOpsTrial {
+    override val classifiers = Set('zipperOps, 'shallow, 'small)
+    override def xmlResource = getClass.getResource("/spending.xml")
+    override def createZipper(xml: Elem) = xml \\ anyElem
+    override def unselectCount = 1
+  }
+  
+  object HugeDeadZipperOps extends Trial('unselectedZipperHuge, "operations on a BIG dead zipper formed via unselect") with ZipperOpsTrial {
+    override val classifiers = Set('zipperOps, 'shallow, 'small)
+    override def xmlResource = getClass.getResource("/spending.xml")
+    override def createZipper(xml: Elem) = (xml \\ anyElem).stripZipper.select(*).unselect 
+    override def unselectCount = 0
+  }
+  
+}

--- a/src/test/scala/com/codecommit/antixml/performance/PerformanceRunner.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/PerformanceRunner.scala
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+package performance
+
+class PerformanceRunner(trials: Seq[Trial]) {
+  import PerformanceRunner._
+
+  /** Runs the trials.
+   */
+  def run(args: Seq[String]) {
+    if (args.contains("--help")) {
+      println(usage)
+      println("%-27s %-30s %s".format("id","classifiers","description"))
+      println("%-27s %-30s %s".format("--","-----------","-----------"))
+      for(t <- trials) {
+        println("%-27s %-30s %s".format(
+          t.id.name,
+          t.classifiers.toSeq.map(_.name).sorted.mkString("(",", ",")"),
+          t.description
+        ))
+      }
+      println()
+    } else {
+      run0(args)
+    }
+  }
+  
+  private def run0(args: Seq[String]) {
+    
+    val (switches,selectors) = Vector(args:_*).partition({_.startsWith("-")})
+    
+    val trialSelector = parseTrialSelector(if (selectors.isEmpty) Seq("0") else selectors)
+    
+    println("-- System Information --")
+    println("Heap: " + (Runtime.getRuntime.maxMemory / (1024 * 1024)) + "MB")
+    println("Java: " + System.getProperty("java.vendor") + " " + System.getProperty("java.version"))
+    println("OS: " + System.getProperty("os.name") + " " + System.getProperty("os.version") + " " + System.getProperty("os.arch"))
+    println()
+
+    val filtered = trials filter {trial: Trial => trialSelector(TrialCriertia(trial))}
+    
+    val filteredLoadTrials = filtered collect {case lt: LoadTrial => lt}
+    
+    for(loadTrial <- filteredLoadTrials) {
+      println("-- Memory Usage ("+loadTrial.sizeDescription+") --")
+      for(impl <- loadTrial.create.sizeMeasurements) {
+        print("%-15s ".format(impl.description+":"))
+        cleanVM()
+        println(deepsize(impl.run()))
+      }
+      println()
+    }
+        
+    if (!filtered.isEmpty) {
+      val f = { () =>
+        println("-- Execution Time --")
+        filtered foreach { trial =>
+          cleanVM()
+          val (_, time) = timedMs(timeTrial(trial, trialSelector))
+          if (switches.contains("--totaltime")) {
+            println("   trial completed in "+time+" ms")
+          }
+          println()
+        }
+      }
+      val iter = if (switches.contains("--loop")) Iterator.continually(f) else Iterator(f)
+      iter foreach {_()}
+    }
+  }
+  
+  private def parseTrialSelector(termStrings: Seq[String]): TrialCriteria => Boolean = {
+    import scala.util.control.Exception.catching
+    
+    object IntString {
+      def unapply(s: String): Option[Int] = catching(classOf[NumberFormatException]) opt {Integer.parseInt(s)}
+    }
+    
+    object Decompose {
+      def unapply(s: String): Option[(Char, String)] = if (s.isEmpty) None else Some(s(0),s drop 1)
+    }
+    
+    def toPred(arg: String): TrialCriteria => Boolean = arg match {
+      case IntString(num) => _.runLevel <= num
+      case Decompose('!',s) => trial => !toPred(s)(trial)
+      case Decompose(':',s) => _.classifiers.contains(Symbol(s))
+      case _ => _.id.name == arg
+    }
+    
+    val terms = termStrings map { arg =>
+      val preds = arg.split("\\&").map(toPred)
+      trial: TrialCriteria => preds forall {p => p(trial)}
+    }
+    trial: TrialCriteria => terms exists {p => p(trial)}
+  }
+  
+
+  private def timedMs[A](f: => A): (A,Long) = {
+    val start = System.nanoTime
+    val res:A = f
+    val elapsed = (System.nanoTime - start) / 1000000
+    (res,elapsed)
+  }
+
+  private def timeTrial(trial: Trial, selector: TrialCriteria => Boolean) {
+    val trialInstance = trial.create
+    println("%-27s %-50s [%s]".format("["+trial.id.name+"]", trial.description, trialInstance.testDataDescription))
+    System.out.flush()
+    cleanVM()
+    val impls = trial.create.implementations filter { impl =>
+      selector(TrialCriteria(impl.id, impl.runLevel, impl.classifiers))
+    }
+    impls foreach { impl =>
+      print(" + %-27s ".format(impl.description+":"))
+      System.out.flush()
+      
+      val warmUpResults = InfoResults((0 until impl.warmUps) map { _ => 
+        val a = impl.preload()
+        val r = impl.run(a)
+        trialInstance.resultDescription(r)
+      })
+      if (!warmUpResults.isValid) 
+        println("ERROR DURING WARMUP: "+warmUpResults)
+      
+      cleanVM()
+      
+      val results = (0 until impl.runs).map { _ =>
+        val a = impl.preload()      // existential types for the win!
+        cleanVM()
+        val (r,t) = timedMs { impl.run(a) }
+        (trialInstance.resultDescription(r), t)
+      }
+      
+      val (infos,times) = results.unzip
+      val timeReport = TimingResults(times).report
+      val infoReport = InfoResults(infos).report
+      println(" %-50s [%s]".format(timeReport,infoReport))
+      System.out.flush()
+    }
+  }
+  
+}
+
+object PerformanceRunner {
+  private case class TrialCriteria(id: Symbol, runLevel: Int, classifiers: Set[Symbol])
+
+  private object TrialCriertia {
+    def apply(t: Trial) = TrialCriteria(t.id, t.runLevel, t.classifiers)
+  }
+  
+  private case class InfoResults(data: Seq[String]) {
+    def report: String =
+      if (!isValid)
+        "MISMATCHED RESULTS: " + List(data:_*)
+      else
+        data.headOption.getOrElse("")
+    
+    def isValid: Boolean = Set(data:_*).size <= 1
+    
+    override def toString = report
+  }
+  
+  private class TimingResults private(val data: Seq[Long], val min: Long, val max: Long, val average: Long) {
+    def report = "min:%4d ms, max:%4d ms, average:%4d ms".format(min,max,average) 
+
+    override def toString = report
+  }
+  
+  private object TimingResults {
+    def apply(results: Seq[Long]): TimingResults = {
+      val (min, max, sum) = results.foldLeft(java.lang.Long.MAX_VALUE, 0L, 0L) { case ((min, max, sum), result) =>
+        (math.min(min, result), math.max(max, result), sum + result)
+      }
+      new TimingResults(results, min, max, sum / results.size)
+    }
+  }
+  
+  val usage = """
+  |usage: [switch]... [selector]...
+  |
+  |A selector consists of one or more predicates separated by "&". Predicates are of the form:
+  |  <id>          - matches any trial with an id of <id>
+  |  :<clasifier>  - matches any trial containing <classifier> in its classifiers set
+  |  any integer   - matches any trial of that runLevel or less
+  |  !<predicate>  - matches any trial that does not match <predicate>
+  |
+  |A selector matches any trial that matches ALL of its predicates. The runner will
+  |execute all trials matching ANY of the selectors on the command line.
+  |
+  |If no selectors are specified, a default selector of "0" is assummed  
+  |
+  |The following switches may be specified:
+  |  --help        - prints this description
+  |  --loop        - repeates the trials until the process is forcibly terminated
+  |  --totaltime   - prints the total time to execute each trial, including setup and teardown
+  |
+  |The following trials may be run:
+  |""".stripMargin
+  
+}

--- a/src/test/scala/com/codecommit/antixml/performance/Trial.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/Trial.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+package performance
+
+import scala.collection.immutable.Set
+
+abstract class Trial(val id: Symbol, val description: String) { self =>
+  val warmUps = 20
+  val runs = 10
+  val runLevel = 0
+
+  val classifiers: Set[Symbol] = Set()
+
+  def create: TrialInstance[_]
+  
+  /** Contains the trial's executable code.  Input data structures should
+    * be kept on this class rather than the `Trial` itself to ensure that they can
+    * be garbage collected when the trial is finished executing.
+    */
+  abstract class TrialInstance[R] {
+    type Result = R
+    
+    type AnyImpl = Implementation[_,R]
+    
+    var implementations: Seq[AnyImpl] = Seq()
+    
+    /** A summary description of the input data to the trial */
+    def testDataDescription: String
+    
+    /** A summary description of the trial output */
+    def resultDescription(value: Result): String
+      
+    object implemented {
+      def by(desc: String) = new {
+        def preload[A](a: =>A) = new {
+          def in(impl: A => R): Implementation[A,R] = {
+            val result = new Implementation[A,R] {
+              val description = desc
+              def trialInstance = TrialInstance.this
+              def preload() = a
+              def run(a: A) = {
+                impl(a)
+              }
+            }
+            implementations = implementations :+ result
+            result
+          }
+        }
+        def in(impl: =>R): Implementation[Unit,R] = {
+          val result = new Implementation[Unit,R] {
+            val description = desc
+            def trialInstance = TrialInstance.this
+            def preload() = ()
+            def run(a: Unit) = {
+              impl
+            }
+          }
+          implementations = implementations :+ result
+          result
+        }
+      }
+    }
+    
+    /** May be overridden to reduce the warmUps for slow implementations */
+    def warmUps(impl: AnyImpl): Int = self.warmUps
+    /** May be overridden to reduce the runs for slow implementations */
+    def runs(impl: AnyImpl): Int = self.runs
+    
+    /** May be overridden to increase the run level of particular implementations */
+    def runLevel(impl: AnyImpl): Int = self.runLevel
+  
+  }
+  
+  trait Implementation[A,R] {
+    type Value = A
+    type Result = R
+    val description: String
+    
+    def trialInstance: TrialInstance[R]
+    
+    def preload(): Value
+    def run(a: Value): Result
+    
+    def runs = trialInstance.runs(this)
+    def warmUps = trialInstance.warmUps(this)
+    def runLevel = trialInstance.runLevel(this)
+    def classifiers = self.classifiers
+    def id = self.id
+  }
+  
+}
+

--- a/src/test/scala/com/codecommit/antixml/performance/XmlCounts.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/XmlCounts.scala
@@ -27,11 +27,39 @@
  */
 
 package com.codecommit.antixml
+package performance
 
-object Performance {
-
-  def main(args: Array[String]) {
-    performance.Performance.main(args)
-  }
+case class XmlCounts(nodes: Int, elements: Int, attributes: Int) {
+  def +(rhs: XmlCounts) = XmlCounts(nodes+rhs.nodes,elements+rhs.elements,attributes+rhs.attributes)
   
+  def report:String = nodes+" nodes, "+elements+" elems, "+attributes+" attrs"
+}
+
+object XmlCounts {
+  def apply(a: Any): XmlCounts = a match {
+    case g: Group[_] => (XmlCounts(0,0,0) /: g) { (acc,n) => acc + count(n) }
+    case n: Node => count(n)
+    case sn: scala.xml.Node => count(sn)
+    case jn: org.w3c.dom.Node => count(jn)
+    case _ => XmlCounts(-1,-1,-1)
+  }
+  private def count(n: Node): XmlCounts = {
+    val top = n match {
+      case Elem(_,_,a,_,_) => XmlCounts(1,1,a.size)
+      case _ => XmlCounts(1,0,0)
+    }
+    (top /: n.children) { (acc,child) => acc + count(child) }
+  }
+  private def count(n: scala.xml.Node): XmlCounts = n match {
+    case e: scala.xml.Elem => 
+      (XmlCounts(1,1,e.attributes.length) /: e.child) { (acc,c) => acc + count(c) }
+    case _ => XmlCounts(1,0,0)
+  }
+  private def count(n: org.w3c.dom.Node): XmlCounts = n match {
+    case e: org.w3c.dom.Element =>
+      (XmlCounts(1,1,e.getAttributes.getLength) /: JavaNodeSeqWithIndexedSeq.wrap(e.getChildNodes)) { (acc,c) => acc + count(c) }
+    case d: org.w3c.dom.Document =>
+      (XmlCounts(0,0,0) /: JavaNodeSeqWithIndexedSeq.wrap(d.getChildNodes)) { (acc,c) => acc + count(c) }
+    case _ => XmlCounts(1,0,0)      
+  }
 }

--- a/src/test/scala/com/codecommit/antixml/performance/modifyTrial.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/modifyTrial.scala
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+package performance
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+trait ModifyTrial {self: Trial =>
+  def xmlResource: java.net.URL
+  
+  trait ModifyInstance extends TrialInstance[Any] {
+    val antiTree = from(xmlResource) {XML.fromInputStream(_)}
+    val scalaTree = from(xmlResource) {scala.xml.XML.load(_)}
+    val domTree = from(xmlResource) {DocumentBuilderFactory.newInstance.newDocumentBuilder.parse(_)}
+    override def resultDescription(a: Any) = "result has "+XmlCounts(a).report
+  }
+}
+
+trait DeepModifyTrial extends ModifyTrial {self: Trial =>
+  val selection: String
+  val attributeToSet: (String,String)
+  
+  class ModifyInstance extends super.ModifyInstance {
+    override def testDataDescription = "modify "+(antiTree \\ selection).length+" nodes"
+    
+    val antiXml = implemented by "anti-xml" in {
+      val sels = (antiTree \\ selection) 
+      val mods = sels map {e => e.copy(attrs = e.attrs + attributeToSet)}
+      mods.unselect
+    }
+    
+    /** Naive scala.xml implementation */ 
+    val scalaXml = implemented by "scala.xml" in {
+      import scala.xml.{Node, Elem, Attribute}
+      def deepMap(node: Node)(f: Node => Node):Node = f(node) match {
+        case e: Elem => e.copy(child=e.child.map(n => deepMap(n)(f)))
+        case n => n
+      }
+      deepMap(scalaTree) {
+        case e@Elem(_,`selection`,attrs,_,_) => e.asInstanceOf[Elem] % (Attribute("",attributeToSet._1,attributeToSet._2,attrs))
+        case n => n
+      }
+    }
+    
+    /** Optimized scala.xml implementation.  Does not call map on seqs that do not contain children. */ 
+    val scalaXml2 = implemented by "scala-xml, opt" in {
+      import scala.xml.{Node, Elem, Attribute}
+      def modify(g: Seq[Node], sel: String)(f: Elem => Elem):Seq[Node] = g map {
+        case e: Elem => {
+          val e2 = if (e.label == sel) f(e) else e
+          if (e2.child.forall({! _.isInstanceOf[Elem]})) e2 else
+            e2.copy(child=modify(e2.child,sel)(f))
+        }
+        case n => n
+      }
+      scalaTree.copy(child = modify(scalaTree.child, selection) { e =>
+        e % (Attribute("",attributeToSet._1,attributeToSet._2,e.attributes))
+      })
+    }
+
+    /** javax.xml implementation, which makes a clone of the dom and then mutates the result.
+     *  The `getElementsByTagName` method is used to find the elements to update. 
+     */ 
+    val javaXml = implemented by "javax.xml" in {
+      val domCopy = domTree.cloneNode(true).asInstanceOf[org.w3c.dom.Document]
+      val sels = domCopy.getElementsByTagName(selection)
+      for(i <- 0 until sels.getLength) {
+        val e = sels.item(i).asInstanceOf[org.w3c.dom.Element]
+        e.setAttribute(attributeToSet._1,attributeToSet._2)
+      }
+      domCopy
+    }
+
+    /** Analog to the naive scala.xml implementation */
+    val antiXml2 = implemented by "anti-xml no-zip" in {
+      def deepMap(node: Node)(f: (Node) => Node):Node = f(node) match {
+        case e: Elem => e.copy(children=e.children.map(n => deepMap(n)(f)))
+        case n => n
+      }
+      deepMap(antiTree) {
+        case e@Elem(_,`selection`,attrs,_,_) => e.asInstanceOf[Elem].copy(attrs = e.attrs +attributeToSet)
+        case n => n
+      }
+    }
+
+    /** Analog to the optimized scala.xml implementation */
+    val antiXml3 = implemented by "anti-xml no-zip, opt" in {
+      def modify(g: Group[Node], sel: String)(f: Elem => Elem):Group[Node] = g map {
+        case e: Elem => {
+          val e2 = if (e.name == sel) f(e) else e
+          if (e2.children.forall({! _.isInstanceOf[Elem]})) e2 else
+            e2.copy(children=modify(e2.children,sel)(f))
+        }
+        case n => n
+      }
+      antiTree.copy(children = modify(antiTree.children, selection) { e =>
+        e.copy(attrs = e.attrs +attributeToSet)
+      })
+    }
+
+    /** Alternate analog to optimized scala.xml, which uses selective update rather than map */
+    val antiXml4 = implemented by "anti-xml no-zip, update" in {
+      def modify(g: Group[Node], sel: String)(f: Elem => Elem):Group[Node] = {
+        (g /: (0 until g.length)) { (acc,i) => 
+          acc(i) match {
+            case e: Elem => {
+              val e2 = if (e.name == sel) f(e) else e
+              val e3c = modify(e2.children,sel)(f)
+              val e3 = if (e3c eq e2.children) e2 else e2.copy(children=e3c)
+              if (e3 eq e) acc else acc.updated(i,e3)
+            }
+            case n => acc
+          }
+        }
+      }
+      antiTree.copy(children = modify(antiTree.children, selection) { e =>
+        e.copy(attrs = e.attrs +attributeToSet)
+      })
+    }
+    
+    /* The alternate impls get suppressed at low run levels: */
+    
+    val lowPriorityImpls:Set[AnyImpl] = Set(scalaXml2,antiXml2,antiXml3,antiXml4)
+    
+    override def runLevel(impl: AnyImpl) = 
+      super.runLevel(impl) + (if (lowPriorityImpls(impl)) 1 else 0) 
+
+  }
+  override def create:ModifyInstance = new ModifyInstance
+}
+
+trait ShallowModifyTrial extends ModifyTrial {self: Trial =>
+  val selection: List[String]
+  val attributeToSet: (String,String)
+  
+  class ModifyInstance extends super.ModifyInstance {
+    override def testDataDescription = "modify "+((antiTree.toGroup /: selection) { (g,s) => g \ s }).length+" nodes"
+    
+    val antiXml = implemented by "anti-xml" in {
+      val s2 = antiTree.toGroup \ selection.head
+      val sels = (s2 /: selection.tail) { (g,s) => g \ s }
+      val mods = sels map {e => e.copy(attrs = e.attrs + attributeToSet)}
+      ((mods:Zipper[Node]) /: selection) { (z, _) => z.unselect}
+    }
+    
+    /** Scala.xml implementation */
+    val scalaXml = implemented by "scala.xml" in {
+      import scala.xml.{Node, Elem, Attribute}
+      def modify(ns: Seq[Node], sels: List[String])(f: Elem => Elem): Seq[Node] = ns map {
+        case e: Elem => sels match {
+          case e.label :: Nil => f(e)
+          case e.label :: rest => e.copy(child=modify(e.child,rest)(f))
+          case _ => e
+        }
+        case n => n
+      }
+      scalaTree.copy(child = modify(scalaTree.child,selection) {e =>
+         e % Attribute("",attributeToSet._1,attributeToSet._2,e.attributes)
+      })
+    }
+    
+    /** javax.xml implementation, which makes a clone of the dom and then mutates the result */     
+    val javaXml = implemented by "javax.xml" in {
+      import org.w3c.dom.{Document, NodeList, Node, Element}
+      val domCopy = domTree.cloneNode(true).asInstanceOf[Document]
+      def modify(nl: NodeList, sels: List[String])(f: Element => Any) {
+        for(indx <- 0 until nl.getLength) nl.item(indx) match {
+          case e: Element => {
+            val name = simpleNameOf(e)
+            sels match {
+              case `name` :: Nil => f(e)
+              case `name` :: rest => modify(e.getChildNodes(), rest)(f)
+              case _ => ()
+            }
+          }
+          case _ => ()
+        }
+      }
+      modify(domCopy.getChildNodes().item(0).getChildNodes(), selection) { e =>
+        e.setAttribute(attributeToSet._1,attributeToSet._2)
+      }
+      domCopy
+    }
+    
+    /** Analog to the scala.xml implementation */
+    val antiXml2 = implemented by "anti-xml no-zip" in {
+      def modify(g: Group[Node], sels: List[String])(f: Elem => Elem): Group[Node] = g map {
+        case e: Elem => sels match {
+          case e.name :: Nil => f(e)
+          case e.name :: rest => e.copy(children=modify(e.children,rest)(f))
+          case _ => e
+        }
+        case n => n
+      }
+      antiTree.copy(children = modify(antiTree.children,selection) {e =>
+         e.copy(attrs = e.attrs + attributeToSet) 
+      })
+    }
+    
+    /* The alternate impls get suppressed at low run levels: */
+    
+    val lowPriorityImpls:Set[AnyImpl] = Set(antiXml2)
+    
+    override def runLevel(impl: AnyImpl) = 
+      super.runLevel(impl) + (if (lowPriorityImpls(impl)) 1 else 0) 
+
+  }
+  override def create:ModifyInstance = new ModifyInstance
+}
+

--- a/src/test/scala/com/codecommit/antixml/performance/package.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/package.scala
@@ -28,10 +28,45 @@
 
 package com.codecommit.antixml
 
-object Performance {
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.Builder
 
-  def main(args: Array[String]) {
-    performance.Performance.main(args)
+package object performance {
+  
+  def simpleNameOf(n: org.w3c.dom.Node) = 
+    if (n.getLocalName == null) n.getNodeName else n.getLocalName
+  
+  
+  def from[A](u: java.net.URL)(f: java.io.InputStream => A): A = {
+    val is = u.openStream()
+    try {
+      f(is)
+    } finally {
+      is.close()
+    }
+  }
+
+  /** Selects elements with the specified name, without taking advantage of the bloom filter.*/
+  def noBloom(s: String) = Selector({case e:Elem if e.name == s => e})
+  
+  /** Selects any element */
+  val anyElem = Selector[Elem] {case e:Elem => e}
+
+  /** A CBFWZ that builds a plain `Group` rather than a `Zipper` */
+  def withoutZipperContext[A <: Node] = CanBuildFromWithZipper.identityCanBuildFrom(new CanBuildFrom[Traversable[_], A, Group[A]] {
+    def apply(from: Traversable[_]): Builder[A, Group[A]] = apply()
+    def apply(): Builder[A, Group[A]] = Group.newBuilder[A]
+  })
+  
+  
+  def cleanVM() {
+    System.gc()
   }
   
+  def deepsize(x: => Any) = {
+    com.github.dmlap.sizeof.SizeOf.deepsize(x)
+  }
+  
+
 }
+

--- a/src/test/scala/com/codecommit/antixml/performance/selectionTrial.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/selectionTrial.scala
@@ -83,12 +83,12 @@ trait ShallowSelectionTrial extends SelectionTrial {self: Trial =>
     val javaXml = implemented by "javax.xml" preload domTree in {xml =>
       applySelections(JavaNodeSeqWithIndexedSeq.wrap(xml.getChildNodes)) { (x,s) => x \ s }
     }
-    val antiXmlNB = implemented by "anti-xml - no bloom" preload antiTree in { xml =>
-      applySelections(xml.toGroup) { (x,s) => x \ noBloom(s) }
-    }
     val antiXmlNZ = implemented by "anti-xml - no zipper" preload antiTree in { xml =>
       val cbfwz = withoutZipperContext[Elem]
       applySelections(xml.toGroup) { (x,s) => x.\(s)(cbfwz) }
+    }
+    val antiXmlNB = implemented by "anti-xml - no bloom" preload antiTree in { xml =>
+      applySelections(xml.toGroup) { (x,s) => x \ noBloom(s) }
     }
   }
   def create: Inst

--- a/src/test/scala/com/codecommit/antixml/performance/selectionTrial.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/selectionTrial.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+package performance
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+import SelectionTrial.JavaPimps._  //Adds \ and \\ operators to dom Documents
+
+trait SelectionTrial {self: Trial =>
+  def xmlResource: java.net.URL
+  
+  trait Inst extends self.TrialInstance[Seq[Seq[_]]] {
+    override def testDataDescription = XmlCounts(antiTree).report
+    override def resultDescription(results: Seq[Seq[_]]) = {
+      val cnt = (0 /: results) { (sum,result) => sum + result.length }
+      "Selected "+cnt+" nodes"
+    }
+    def antiTree: Elem
+    def scalaTree: scala.xml.Elem
+    def domTree: org.w3c.dom.Document
+    
+    val lowPriorityImpls:Set[AnyImpl]
+    
+    override def runLevel(impl: AnyImpl) = 
+      super.runLevel(impl) + (if (lowPriorityImpls(impl)) 1 else 0) 
+
+  }
+  def create: Inst
+}
+
+object SelectionTrial {
+  class JavaDocumentPimp(doc: org.w3c.dom.Document) {
+    def \\(name: String): JavaNodeSeqWithIndexedSeq = 
+      JavaNodeSeqWithIndexedSeq.copy(doc.getElementsByTagName(name)) //Using `copy` to force list to be realized
+    def \(name: String): JavaNodeSeqWithIndexedSeq = JavaNodeSeqWithIndexedSeq.wrap(doc.getChildNodes) \ name
+  }
+
+  object JavaPimps {
+    implicit def wrap(doc: org.w3c.dom.Document): JavaDocumentPimp = new JavaDocumentPimp(doc)
+  }
+}
+
+trait ShallowSelectionTrial extends SelectionTrial {self: Trial =>
+  val selections: List[List[String]] //always use List to ensure all trials are consistent 
+  
+  def applySelections[A](a: A)(fSel: (A, String) => A) = 
+    selections map {ss => (a /: ss)(fSel)}  
+  
+  trait Inst extends super.Inst {
+    val antiXml = implemented by "anti-xml" preload antiTree in { xml =>
+      applySelections(xml.toGroup) { (x,s) => x \ s }
+    }
+    val scalaXml = implemented by "scala.xml" preload scalaTree in { xml =>
+      applySelections(xml:scala.xml.NodeSeq) { (x,s) => x \ s }
+    }
+    val javaXml = implemented by "javax.xml" preload domTree in {xml =>
+      applySelections(JavaNodeSeqWithIndexedSeq.wrap(xml.getChildNodes)) { (x,s) => x \ s }
+    }
+    val antiXmlNB = implemented by "anti-xml - no bloom" preload antiTree in { xml =>
+      applySelections(xml.toGroup) { (x,s) => x \ noBloom(s) }
+    }
+    val antiXmlNZ = implemented by "anti-xml - no zipper" preload antiTree in { xml =>
+      val cbfwz = withoutZipperContext[Elem]
+      applySelections(xml.toGroup) { (x,s) => x.\(s)(cbfwz) }
+    }
+  }
+  def create: Inst
+}
+
+trait DeepSelectionTrial extends SelectionTrial {self: Trial =>
+  val selections: List[String] //always use List to ensure all trials are consistent 
+  
+  def applySelections[A,B](a: A)(fSel: (A, String) => B) = 
+    selections map {ss => fSel(a,ss)}  
+  
+  trait Inst extends super.Inst {
+    val antiXml = implemented by "anti-xml" preload antiTree in { xml =>
+      applySelections(xml) { (x,s) => x \\ s }
+    }
+    val scalaXml = implemented by "scala.xml" preload scalaTree in { xml =>
+      applySelections(xml:scala.xml.NodeSeq) { (x,s) => x \\ s }
+    }
+    val javaXml = implemented by "javax.xml" preload domTree in {xml =>
+      applySelections(xml) { (x,s) => x \\ s }
+    }
+    val antiXmlNZ = implemented by "anti-xml - no zipper" preload antiTree in { xml =>
+      val cbfwz = withoutZipperContext[Elem]
+      applySelections(xml) { (x,s) => x.\\(s)(cbfwz) }
+    }
+    val antiXmlNB = implemented by "anti-xml - no bloom" preload antiTree in { xml =>
+      applySelections(xml) { (x,s) => x \\ noBloom(s) }
+    }
+  }
+  def create:Inst
+}
+
+
+trait ColdShallowSelectionTrial extends ShallowSelectionTrial {self: Trial =>
+  class Inst extends super.Inst {
+    override def antiTree = from(xmlResource) {XML.fromInputStream(_)}
+    override def scalaTree = from(xmlResource) {scala.xml.XML.load(_)}
+    override def domTree = from(xmlResource) {DocumentBuilderFactory.newInstance.newDocumentBuilder.parse(_)}
+    override val lowPriorityImpls:Set[AnyImpl] = Set(antiXmlNZ)
+  }
+  override def create:Inst = new Inst
+}
+
+trait WarmShallowSelectionTrial extends ShallowSelectionTrial { self: Trial =>
+  class Inst extends super.Inst {
+    override val antiTree = from(xmlResource) {XML.fromInputStream(_)}
+    override val scalaTree = from(xmlResource) {scala.xml.XML.load(_)}
+    override val domTree = from(xmlResource) {DocumentBuilderFactory.newInstance.newDocumentBuilder.parse(_)}
+    override val lowPriorityImpls:Set[AnyImpl] = Set(antiXmlNB,antiXmlNZ)
+  }
+  override def create:Inst = new Inst
+}
+
+trait ColdDeepSelectionTrial extends DeepSelectionTrial {self: Trial =>
+  class Inst extends super.Inst {
+    override def antiTree = from(xmlResource) {XML.fromInputStream(_)}
+    override def scalaTree = from(xmlResource) {scala.xml.XML.load(_)}
+    override def domTree = from(xmlResource) {DocumentBuilderFactory.newInstance.newDocumentBuilder.parse(_)}
+    override val lowPriorityImpls:Set[AnyImpl] = Set(antiXmlNZ)
+  }
+  override def create:Inst = new Inst
+}
+
+trait WarmDeepSelectionTrial extends DeepSelectionTrial { self: Trial =>
+  class Inst extends super.Inst {
+    override val antiTree = from(xmlResource) {XML.fromInputStream(_)}
+    override val scalaTree = from(xmlResource) {scala.xml.XML.load(_)}
+    override val domTree = from(xmlResource) {DocumentBuilderFactory.newInstance.newDocumentBuilder.parse(_)}
+    override val lowPriorityImpls:Set[AnyImpl] = Set(antiXmlNB,antiXmlNZ)
+  }
+  override def create:Inst = new Inst
+}
+

--- a/src/test/scala/com/codecommit/antixml/performance/zipperOperationsTrial.scala
+++ b/src/test/scala/com/codecommit/antixml/performance/zipperOperationsTrial.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer. 
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.codecommit.antixml
+package performance
+
+trait ZipperOpsTrial { self: Trial =>
+  
+  def xmlResource: java.net.URL
+  def createZipper(xml: Elem): Zipper[Node]
+  def unselectCount = 1
+  //If necessary, override nodePred so that about half the nodes match.
+  def nodePred(n: Node): Boolean = n match {
+    case e:Elem => (e.name.length & 1) == 0
+    case _ => false
+  }        
+  
+  class ZipperOpsInstance extends TrialInstance[Seq[Node]] {      
+    val zipper = createZipper(from(xmlResource) {XML.fromInputStream(_)})
+    val nonZipper = zipper.stripZipper
+    val unselectCount = ZipperOpsTrial.this.unselectCount
+    val sliceRange = ((zipper.length / 4), 3*(zipper.length / 4))
+    
+    override def resultDescription(s: Seq[Node]) = "result has length="+s.length+" and "+XmlCounts(s).report
+    override def testDataDescription = "zipper has length="+zipper.length+" and "+XmlCounts(zipper).report
+
+    val unselect = implemented by "zipper.unselect" in {
+      (zipper /: (0 until unselectCount)) { (z,_) => z.unselect}
+    }
+    val zupdate = implemented by "zipper.updated" in {
+      (zipper /: (0 until zipper.length)) { (z,i) => z.updated(i,Text("updated")) }
+    }
+    val gupdate = implemented by "group.updated" in {
+      (nonZipper /: (0 until zipper.length)) { (z,i) => z.updated(i,Text("updated")) }
+    }
+    val zmap = implemented by "zipper.map" in {
+      zipper map {_ => Text("replaced")}
+    }
+    val gmap = implemented by "group.map" in {
+      nonZipper map {_ => Text("replaced")}
+    }
+    val zfmap = implemented by "zipper.flatmap" in {
+      zipper flatMap {n => if (nodePred(n)) Seq(Text("rep1"),Text("rep2")) else Seq() }
+    }
+    val nzfmap = implemented by "group.flatmap" in {
+      nonZipper flatMap {n => if (nodePred(n)) Seq(Text("rep1"),Text("rep2")) else Seq() }
+    }
+    val zslice = implemented by "zipper.slice" in {
+      zipper.slice(sliceRange._1, sliceRange._2)
+    }
+    val nslice = implemented by "group.slice" in {
+      nonZipper.slice(sliceRange._1, sliceRange._2)
+    }
+    val zfilter = implemented by "zipper.filter" in {
+      zipper filter nodePred
+    }
+    val gfilter = implemented by "group.filter" in {
+      nonZipper filter nodePred
+    }
+  }
+  
+  def create: ZipperOpsInstance = new ZipperOpsInstance
+
+}
+  

--- a/src/test/scala/com/codecommit/antixml/util/VectorCaseSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/util/VectorCaseSpecs.scala
@@ -179,6 +179,14 @@ class VectorCaseSpecs extends Specification with ScalaCheck {
       vec.foldLeft(0) { _ + _ } === list.foldLeft(0) { _ + _ }
     }
     
+    "implement foreach" in check { vec: VectorCase[Int] =>
+      val b = Vector.newBuilder[Int]
+      for(i <- vec)
+        b += i
+      val v = b.result()
+      v mustEqual vec
+    }
+    
     "implement forall" in check { (vec: VectorCase[Int], f: (Int)=>Boolean) =>
       val bool = vec forall f
       


### PR DESCRIPTION
This request contains several new performance trials and some very significant optimizations.   I'll discuss the results of the new trials in #60.  

Note that my earlier `Zipper` refactor hurt selection times compared to the very high bar @ncreep had set.  These optimizations bring the performance back to that level and beyond.

Performance Tests:
- Added several new trials to measure various Zipper operations as well as overall "select/modify/unselect" times
- Added new implementations to selection trials to isolate the effect of the Zipper and of the bloom filter on selection times
- Moved Performance into its own package and split it into multiple classes
- New command line options to run certain "categories" of trials (load, selection, modify, etc.) 

Optimizations:
- Put hole information in its own tree structure (`ZipperHoleMap`) rather than a SortedMap
- Defer expensive zipper calculations to `unselect`
- Avoid Int boxing in non-transient path structures (`ZipperPath`)
- Use VectorCase wherever small vectors are likely
- Make PathCreator.PathVals traverse selections lazily
- Reuse empty Group instances (helps with size and with the bloom filter calculation)

This pull request does contain a large number files, but most of them are in the `test` directory.   Many of them are the result of splitting out the Performance class.
