### PR TITLE
Improved performance of preconditions on strings

### DIFF
--- a/src/main/scala/com/codecommit/antixml/Attributes.scala
+++ b/src/main/scala/com/codecommit/antixml/Attributes.scala
@@ -86,10 +86,10 @@ import com.codecommit.antixml.util.OrderPreservingMap
  * @see [[com.codecommit.antixml.QName]]
  */
 class Attributes private (delegate: OrderPreservingMap[QName, String]) extends Map[QName, String] with MapLike[QName, String, Attributes] {
-  import Node.CharRegex
+  import Node.hasOnlyValidChars
 
   for ((name, value) <- delegate) {
-    if (CharRegex.unapplySeq(value).isEmpty) 
+    if (!hasOnlyValidChars(value))
       throw new IllegalArgumentException("Illegal character in attribute value '" + value + "'")
   }
 

--- a/src/main/scala/com/codecommit/antixml/QName.scala
+++ b/src/main/scala/com/codecommit/antixml/QName.scala
@@ -29,15 +29,15 @@
 package com.codecommit.antixml
 
 case class QName(prefix: Option[String], name: String) {
-  import Elem.NameRegex
+  import Elem.isValidName
   
   for (p <- prefix) {
-    if (NameRegex.unapplySeq(p).isEmpty) {
+    if (! isValidName(p)) {
       throw new IllegalArgumentException("Illegal element prefix, '" + p + "'")
     }
   }
   
-  if (NameRegex.unapplySeq(name).isEmpty) {
+  if (! isValidName(name)) {
     throw new IllegalArgumentException("Illegal attribute name, '" + name + "'")
   }
   

--- a/src/test/scala/com/codecommit/antixml/ConversionSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ConversionSpecs.scala
@@ -35,7 +35,7 @@ import org.scalacheck._
 import scala.xml
 
 class ConversionSpecs extends Specification with ScalaCheck {
-  import Node.CharRegex
+  import Node.hasOnlyValidChars
   import Prop._
   
   "scala.xml explicit conversions" should {
@@ -60,7 +60,7 @@ class ConversionSpecs extends Specification with ScalaCheck {
     }
 
     "convert text nodes" in check { str: String =>
-      if (!CharRegex.unapplySeq(str).isEmpty) {
+      if (hasOnlyValidChars(str)) {
         val node = xml.Text(str)
         node.convert mustEqual Text(str)
       } else {
@@ -69,7 +69,7 @@ class ConversionSpecs extends Specification with ScalaCheck {
     }
     
     "convert entity references" in check { str: String =>
-      if (!CharRegex.unapplySeq(str).isEmpty) {
+      if (hasOnlyValidChars(str)) {
         val ref = xml.EntityRef(str)
         ref.convert mustEqual EntityRef(str)
         (ref: xml.Node).convert mustEqual EntityRef(str)

--- a/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/GroupSpecs.scala
@@ -226,10 +226,10 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
   }
 
   "canonicalization" should {
-    import Node.CharRegex
+    import Node.hasOnlyValidChars
     
     "merge two adjacent text nodes" in check { (left: String, right: String) =>
-      if (!CharRegex.unapplySeq(left + right).isEmpty) {
+      if (hasOnlyValidChars(left + right)) {
         Group(Text(left), Text(right)).canonicalize mustEqual Group(Text(left + right))
         Group(CDATA(left), CDATA(right)).canonicalize mustEqual Group(CDATA(left + right))
       } else {
@@ -238,7 +238,7 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
     }
     
     "merge two adjacent text nodes at end of Group" in check { (left: String, right: String) =>
-      if (!CharRegex.unapplySeq(left + right).isEmpty) {
+      if (hasOnlyValidChars(left + right)) {
         Group(elem("foo"), elem("bar", Text("test")), Text(left), Text(right)).canonicalize mustEqual Group(elem("foo"), elem("bar", Text("test")), Text(left + right))
         Group(elem("foo"), elem("bar", Text("test")), CDATA(left), CDATA(right)).canonicalize mustEqual Group(elem("foo"), elem("bar", Text("test")), CDATA(left + right))
       } else {
@@ -247,7 +247,7 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
     }
     
     "merge two adjacent text nodes at beginning of Group" in check { (left: String, right: String) =>
-      if (!CharRegex.unapplySeq(left + right).isEmpty) {
+      if (hasOnlyValidChars(left + right)) {
         Group(Text(left), Text(right), elem("foo"), elem("bar", Text("test"))).canonicalize mustEqual Group(Text(left + right), elem("foo"), elem("bar", Text("test")))
         Group(CDATA(left), CDATA(right), elem("foo"), elem("bar", Text("test"))).canonicalize mustEqual Group(CDATA(left + right), elem("foo"), elem("bar", Text("test")))
       } else {
@@ -256,7 +256,7 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
     }
     
     "merge two adjacent text nodes at depth" in check { (left: String, right: String) =>
-      if (!CharRegex.unapplySeq(left + right).isEmpty) {
+      if (hasOnlyValidChars(left + right)) {
         Group(elem("foo", elem("bar", Text(left), Text(right)))).canonicalize mustEqual Group(elem("foo", elem("bar", Text(left + right))))
         Group(elem("foo", elem("bar", CDATA(left), CDATA(right)))).canonicalize mustEqual Group(elem("foo", elem("bar", CDATA(left + right))))
       } else {
@@ -265,7 +265,7 @@ class GroupSpecs extends Specification with ScalaCheck with XMLGenerators with U
     }
     
     "not merge adjacent text and cdata nodes" in check { (left: String, right: String) =>
-      if (!CharRegex.unapplySeq(left + right).isEmpty) {
+      if (hasOnlyValidChars(left + right)) {
         Group(CDATA(left), Text(right)).canonicalize mustEqual Group(CDATA(left), Text(right))
         Group(Text(left), CDATA(right)).canonicalize mustEqual Group(Text(left), CDATA(right))
       } else {


### PR DESCRIPTION
Replaced !regex.unapplySeq.isEmpty by regex.pattern.matcher(_).matches.

This avoids a lot of allocations of unneeded objects and improves the 
overall performance on Android by a factor of 2-3 (for my use case).
