### PR TITLE
XPath axes for Zipper

### DIFF
--- a/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
+++ b/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
@@ -103,27 +103,25 @@ object CanBuildFromWithZipper {
    * Both types are represented as concrete subclasses of this one.
    *
    * @tparam Elem the type of node that will be contained in the zipper.
+   * @param path A zipper path instance leading to the location of the hole.
    * @param updateTime the update time associated with these elements.  One context is considered to have
    * been updated later than another if its updateTime is greater.
    * @see [[com.codecommit.antixml.CanBuildFromWithZipper]]
    */
-  sealed abstract class ElemsWithContext[+Elem](updateTime: Int)
+  sealed abstract class ElemsWithContext[+Elem](path: ZipperPath, updateTime: Int)
   /**
    * A visible zipper element.
-   * @param path Identifies a location (known as a "hole") in the zipper's parent.  The order of the
-   * path is from top to bottom (the first item specifies the index of a top-level node in the parent Group).
    * @param elements the actual elements to be added to the zipper. 
    */
-	case class ElemsWithContextVisible[+Elem](path: Seq[Int], updateTime: Int, elements: GenTraversableOnce[Elem]) extends ElemsWithContext[Elem](updateTime)
+	case class ElemsWithContextVisible[+Elem](path: ZipperPath, updateTime: Int, elements: GenTraversableOnce[Elem]) extends ElemsWithContext[Elem](path, updateTime)
   /**
    * A hidden zipper element.
    * @tparam Elem Dummy parameterization to satisfy the signature of methods like `flatMap`.
-   * @param path A zipper path instance leading to the location of the hole.
    * @param elements The elements to be mapped to the path contained in the context. The type
    * of the elements is the most general as they are not accessible through the zipper's methods
    * and hence do not participate in any sort of transformations.
    */
-  case class ElemsWithContextHidden(path: ZipperPath, updateTime: Int, elements: GenTraversableOnce[Node]) extends ElemsWithContext[Nothing](updateTime)
+  case class ElemsWithContextHidden(path: ZipperPath, updateTime: Int, elements: GenTraversableOnce[Node]) extends ElemsWithContext[Nothing](path, updateTime)
   
   /** Implicitly lifts [[scala.collection.mutable.CanBuildFrom]] instances into instances of [[com.codecommit.antixml.CanBuildFromWithZipper]]. The resulting builders simply ignore
     * the extra information in `ElemsWithContext` and produce their collections as usual.

--- a/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
+++ b/src/main/scala/com/codecommit/antixml/CanBuildFromWithZipper.scala
@@ -109,11 +109,13 @@ object CanBuildFromWithZipper {
    * @see [[com.codecommit.antixml.CanBuildFromWithZipper]]
    */
   sealed abstract class ElemsWithContext[+Elem](path: ZipperPath, updateTime: Int)
+  
   /**
    * A visible zipper element.
    * @param elements the actual elements to be added to the zipper. 
    */
-	case class ElemsWithContextVisible[+Elem](path: ZipperPath, updateTime: Int, elements: GenTraversableOnce[Elem]) extends ElemsWithContext[Elem](path, updateTime)
+  case class ElemsWithContextVisible[+Elem](path: ZipperPath, updateTime: Int, elements: GenTraversableOnce[Elem]) extends ElemsWithContext[Elem](path, updateTime)
+  
   /**
    * A hidden zipper element.
    * @tparam Elem Dummy parameterization to satisfy the signature of methods like `flatMap`.

--- a/src/main/scala/com/codecommit/antixml/PathFetcher.scala
+++ b/src/main/scala/com/codecommit/antixml/PathFetcher.scala
@@ -1,0 +1,25 @@
+package com.codecommit.antixml
+import scala.annotation.tailrec
+
+/**
+ * Fetches [[com.codecommit.antixml.ZipperPath]]s from within a [[com.codecommit.antixml.Group]] 
+ */
+object PathFetcher { //TODO test
+	
+  /**  
+   * @param source The group upon which the fetching is performed.
+   * @param path The path to be fetched, assumed to be valid for the given source.
+   * @return An optional node at the end of the path. */
+  def getNode(source: Group[Node])(path: ZipperPath): Option[Node] = getNodeRec(source, path)
+
+  @tailrec
+  private def getNodeRec(currLevel: Group[Node], path: ZipperPath): Option[Node] = {
+    if (path.isEmpty) None
+    else if (path.size == 1) Some(currLevel(path.head))
+    else {
+      // the cast must succeed otherwise the path is invalid
+      val children = currLevel(path.head).asInstanceOf[Elem].children
+      getNodeRec(children, path.tail)
+    }
+  }
+}

--- a/src/main/scala/com/codecommit/antixml/PathFetcher.scala
+++ b/src/main/scala/com/codecommit/antixml/PathFetcher.scala
@@ -4,7 +4,9 @@ import scala.annotation.tailrec
 /**
  * Fetches [[com.codecommit.antixml.ZipperPath]]s from within a [[com.codecommit.antixml.Group]] 
  */
-object PathFetcher { //TODO test
+object PathFetcher {
+  
+  //TODO state monad for caching?
 	
   /**  
    * @param source The group upon which the fetching is performed.

--- a/src/main/scala/com/codecommit/antixml/PathTransformer.scala
+++ b/src/main/scala/com/codecommit/antixml/PathTransformer.scala
@@ -54,7 +54,3 @@ private[antixml] case class PathTransformer(source: Group[Node]) {
       else None
   }
 }
-
-private[antixml] object PathTransformer {
-  private[antixml]type PathCache = Map[ZipperPath, Option[Node]]
-}

--- a/src/main/scala/com/codecommit/antixml/PathTransformer.scala
+++ b/src/main/scala/com/codecommit/antixml/PathTransformer.scala
@@ -1,0 +1,76 @@
+package com.codecommit.antixml
+
+import scala.annotation.tailrec
+import PathTransformer._
+
+/** Transforms [[com.codecommit.antixml.ZipperPath]]s with predefined functions.
+ *
+ *  The transformations rely on a source parent group from which all paths are
+ *  calculated. Any paths passed to instances of this class are assumed to be valid
+ *  paths in the source group.
+ *
+ *  @param source The source for the transformed paths.
+ */
+private[antixml] case class PathTransformer(source: Group[Node]) {
+  //TODO this whole class is probably quite slow
+  //TODO state monad for caching?
+
+  /** Shifts the path one step upwards, if possible.
+   * @param path The path to be shifted
+   * @return An optional path which is the parent of the original path, a new path transformer
+   * with an updated cache. */
+  def shiftUp(path: ZipperPath): Option[ZipperPath] = if (path.isEmpty) None else Some(path.init)
+
+  /** Shifts the path one step to the left, if possible.
+   * @param path The path to be shifted
+   * @return An optional path which is a sibling of the original path from the left, a new path transformer
+   * with an updated cache. */
+  def shiftLeft(path: ZipperPath): Option[ZipperPath] = {
+    shiftSideways(path, -1)
+  }
+
+  /** Shifts the path one step to the right, if possible.
+   * @param path The path to be shifted
+   * @return An optional path which is a sibling of the original path from the right, a new path transformer
+   * with an updated cache. */
+  def shiftRight(path: ZipperPath): Option[ZipperPath] = {
+    shiftSideways(path, +1)
+  }
+
+  /** @return An optional node at the end of the path and updated cache. */
+  private def getNode(path: ZipperPath): Option[Node] = getNode(source, path)
+
+  @tailrec
+  private def getNode(currLevel: Group[Node], path: ZipperPath): Option[Node] = {
+    if (path.isEmpty) None
+    else if (path.size == 1) Some(currLevel(path.head))
+    else {
+      // the cast must succeed otherwise the path is invalid
+      val children = currLevel(path.head).asInstanceOf[Elem].children
+      getNode(children, path.tail)
+    }
+  }
+
+  /** Tries to shift the path sideways by the given increment. */
+  private def shiftSideways(path: ZipperPath, increment: Int): Option[ZipperPath] = {
+    assert(!path.isEmpty, "Cannot shift an empty path.")
+
+    val currLevel =
+      if (path.size == 1) source
+      else {
+        val parent = getNode(path.init) // size > 1
+        parent.get.asInstanceOf[Elem].children // must be an elem for a valid path
+      }
+
+    val end = path.size - 1
+
+    val newLoc = path(end) + increment
+
+      if (currLevel.indices.contains(newLoc)) Some(path.updated(end, newLoc))
+      else None
+  }
+}
+
+private[antixml] object PathTransformer {
+  private[antixml]type PathCache = Map[ZipperPath, Option[Node]]
+}

--- a/src/main/scala/com/codecommit/antixml/PathTransformer.scala
+++ b/src/main/scala/com/codecommit/antixml/PathTransformer.scala
@@ -2,6 +2,7 @@ package com.codecommit.antixml
 
 import scala.annotation.tailrec
 import PathTransformer._
+import PathFetcher._
 
 /** Transforms [[com.codecommit.antixml.ZipperPath]]s with predefined functions.
  *
@@ -17,38 +18,21 @@ private[antixml] case class PathTransformer(source: Group[Node]) {
 
   /** Shifts the path one step upwards, if possible.
    * @param path The path to be shifted
-   * @return An optional path which is the parent of the original path, a new path transformer
-   * with an updated cache. */
+   * @return An optional path which is the parent of the original path. */
   def shiftUp(path: ZipperPath): Option[ZipperPath] = if (path.isEmpty) None else Some(path.init)
 
   /** Shifts the path one step to the left, if possible.
    * @param path The path to be shifted
-   * @return An optional path which is a sibling of the original path from the left, a new path transformer
-   * with an updated cache. */
+   * @return An optional path which is a sibling of the original path from the left. */
   def shiftLeft(path: ZipperPath): Option[ZipperPath] = {
     shiftSideways(path, -1)
   }
 
   /** Shifts the path one step to the right, if possible.
    * @param path The path to be shifted
-   * @return An optional path which is a sibling of the original path from the right, a new path transformer
-   * with an updated cache. */
+   * @return An optional path which is a sibling of the original path from the right. */
   def shiftRight(path: ZipperPath): Option[ZipperPath] = {
     shiftSideways(path, +1)
-  }
-
-  /** @return An optional node at the end of the path and updated cache. */
-  private def getNode(path: ZipperPath): Option[Node] = getNode(source, path)
-
-  @tailrec
-  private def getNode(currLevel: Group[Node], path: ZipperPath): Option[Node] = {
-    if (path.isEmpty) None
-    else if (path.size == 1) Some(currLevel(path.head))
-    else {
-      // the cast must succeed otherwise the path is invalid
-      val children = currLevel(path.head).asInstanceOf[Elem].children
-      getNode(children, path.tail)
-    }
   }
 
   /** Tries to shift the path sideways by the given increment. */
@@ -58,7 +42,7 @@ private[antixml] case class PathTransformer(source: Group[Node]) {
     val currLevel =
       if (path.size == 1) source
       else {
-        val parent = getNode(path.init) // size > 1
+        val parent = getNode(source)(path.init) // size > 1
         parent.get.asInstanceOf[Elem].children // must be an elem for a valid path
       }
 

--- a/src/main/scala/com/codecommit/antixml/PathTransformer.scala
+++ b/src/main/scala/com/codecommit/antixml/PathTransformer.scala
@@ -13,8 +13,8 @@ import PathFetcher._
  *  @param source The source for the transformed paths.
  */
 private[antixml] case class PathTransformer(source: Group[Node]) {
-  //TODO this whole class is probably quite slow
-  //TODO state monad for caching?
+  //TODO this whole class is probably quite slow, ZipperPath is not optimized for modifications
+  
 
   /** Shifts the path one step upwards, if possible.
    * @param path The path to be shifted

--- a/src/main/scala/com/codecommit/antixml/PathTransformer.scala
+++ b/src/main/scala/com/codecommit/antixml/PathTransformer.scala
@@ -19,7 +19,7 @@ private[antixml] case class PathTransformer(source: Group[Node]) {
   /** Shifts the path one step upwards, if possible.
    * @param path The path to be shifted
    * @return An optional path which is the parent of the original path. */
-  def shiftUp(path: ZipperPath): Option[ZipperPath] = if (path.isEmpty) None else Some(path.init)
+  def shiftUp(path: ZipperPath): Option[ZipperPath] = if (path.isEmpty || path.size == 1) None else Some(path.init)
 
   /** Shifts the path one step to the left, if possible.
    * @param path The path to be shifted

--- a/src/main/scala/com/codecommit/antixml/Selectable.scala
+++ b/src/main/scala/com/codecommit/antixml/Selectable.scala
@@ -29,11 +29,11 @@
 package com.codecommit
 package antixml
 
-import com.codecommit.antixml.util.VectorCase
 import scala.collection.generic.{CanBuildFrom, HasNewBuilder}
-import scala.collection.immutable.{Vector, VectorBuilder}
+import scala.collection.immutable.VectorBuilder
 
-import CanBuildFromWithZipper.ElemsWithContext
+import com.codecommit.antixml.CanBuildFromWithZipper.ElemsWithContextVisible
+import com.codecommit.antixml.util.VectorCase
 
 trait Selectable[+A <: Node] {
   import PathCreator.{allChildren, directChildren, fromNodes, allMaximalChildren, PathFunction, PathVal}
@@ -195,7 +195,7 @@ trait Selectable[+A <: Node] {
     val grp = toGroup
     val bld = cbfwz(Some(toZipper), grp)
     for( PathVal(value, path) <- pf(grp) ) {
-      bld += ElemsWithContext[B](path, 0, VectorCase(value))
+      bld += ElemsWithContextVisible[B](path, 0, VectorCase(value))
     }
     bld.result()
   }

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -197,7 +197,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
           
           val holes = 
             if (nodesTimes.isEmpty) Seq((path, masterTime, util.Vector0))
-            else nodesTimes.map { case (n, t) => (path, t, Seq(n)) }
+            else nodesTimes.map { case (n, t) => (path, t, Seq(n)) } // this contains duplicates for multiplied locations
           
           val visible = (ElemsWithContextVisible.apply[Node] _).tupled
           val hidden = (ElemsWithContextHidden.apply _).tupled
@@ -211,9 +211,12 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
         }
 
       val initTime = 0 // these paths were never modified
-      val unusedElems = unusedPaths.toList map(p => ElemsWithContextVisible[Node](p, initTime, PathFetcher.getNode(parent)(p)))
+      val unusedElems = unusedPaths.toList map { p =>
+    	ElemsWithContextVisible[Node](p, initTime, PathFetcher.getNode(parent)(p))
+      }
       
-      val visibleElems = SortedSet(unusedElems ++ usedPaths: _*)(Ordering.by(_.path))
+      // this can contain duplicate locations from the previously used paths
+      val visibleElems = (unusedElems ++ usedPaths).sortBy(_.path)
       b ++= visibleElems
       
       b.result

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -34,9 +34,10 @@ import scala.collection.{immutable, mutable, IndexedSeqLike, GenTraversableOnce}
 import scala.collection.generic.{CanBuildFrom, FilterMonadic}
 import scala.collection.immutable.{SortedMap, IndexedSeq}
 import scala.collection.mutable.Builder
-
 import Zipper._
 import CanBuildFromWithZipper.ElemsWithContext
+import com.codecommit.antixml.CanBuildFromWithZipper.ElemsWithContextVisible
+import com.codecommit.antixml.CanBuildFromWithZipper.ElemsWithContextHidden
 
 /** 
  * Provides an `unselect` operation which copies this Group's nodes back to the XML tree from which
@@ -141,11 +142,11 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
   override protected[this] def newBuilder = Zipper.newBuilder[A]
   
   override def updated[B >: A <: Node](index: Int, node: B): Zipper[B] = context match {
-    case Some(Context(parent, lastUpdate, metas, additionalHoles)) => {
+    case Some(Context(parent, lastUpdate, metas, additionalHoles, hiddenNodes)) => {
       val updatedTime = lastUpdate + 1
       val (updatedPath,_) = metas(index)
       val updatedMetas = metas.updated(index, (updatedPath, updatedTime))
-      val ctx = Context(parent, updatedTime, updatedMetas, additionalHoles)
+      val ctx = Context(parent, updatedTime, updatedMetas, additionalHoles, hiddenNodes)
       
       new Group(nodes.updated(index, node)) with Zipper[B] {
         val context = Some(ctx)
@@ -155,7 +156,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
   }
 
   override def slice(from: Int, until: Int): Zipper[A] = context match {
-    case Some(Context(parent, lastUpdate, metas, additionalHoles)) => {
+    case Some(Context(parent, lastUpdate, metas, additionalHoles, hiddenNodes)) => {
       val lo = math.min(math.max(from, 0), nodes.length)
       val hi = math.min(math.max(until, lo), nodes.length)
       val cnt = hi - lo
@@ -168,7 +169,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
       for(i <- hi until nodes.length)
         ahs += ((metas(i)._1, lastUpdate + 1 + i - cnt))
       
-      val ctx = Context(parent, lastUpdate + length - cnt, metas.slice(from, until), ahs.result())
+      val ctx = Context(parent, lastUpdate + length - cnt, metas.slice(from, until), ahs.result(), hiddenNodes)
       
       new Group(nodes.slice(from,until)) with Zipper[A] {
         val context = Some(ctx)
@@ -197,15 +198,19 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
 
   override def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit cbf: CanBuildFrom[Zipper[A], B, That]): That = cbf match {
     case cpz: CanProduceZipper[Zipper[A], B, That] if context.isDefined => {
-      val Context(parent, lastUpdate, metas, additionalHoles) = context.get
+      val Context(parent, lastUpdate, metas, additionalHoles, hiddenNodes) = context.get
       val b = cpz.lift(Some(parent), this)
       for(i <- 0 until nodes.length) {
         val (path,_) = metas(i)
-        b += ElemsWithContext(path, lastUpdate+i+1, f(nodes(i)))
+        b += ElemsWithContextVisible(path, lastUpdate+i+1, f(nodes(i)))
       }
-      for ((path,time) <- additionalHoles) {
-        b += ElemsWithContext[B](path,time,util.Vector0)
+
+      for ((path, time) <- additionalHoles) {
+        b += ElemsWithContextVisible[B](path, time, util.Vector0)
       }
+
+      b ++= hiddenNodes 
+
       b.result()
     }
     case _ => {
@@ -247,7 +252,7 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
     /* See the Group implementation for information about how this function is optimized. */ 
     context match {
       case None => brokenZipper(new Group(nodes).conditionalFlatMapWithIndex(f).nodes)
-      case Some(Context(parent, lastUpdate, metas, additionalHoles)) => {
+      case Some(Context(parent, lastUpdate, metas, additionalHoles, hiddenNodes)) => {
         //Optimistic function that uses `update`
         @tailrec
         def update(z: Zipper[B], index: Int): Zipper[B] = {
@@ -268,20 +273,24 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
           
           for(i <- 0 until index) {
             val (p,t) = zc.metas(i)
-            b += ElemsWithContext(p,t,util.Vector1(z(i)))
+            b += ElemsWithContextVisible(p,t,util.Vector1(z(i)))
           }
-          b += ElemsWithContext(metas(index)._1, zc.lastUpdate+1,currentReplacements)
+          b += ElemsWithContextVisible(metas(index)._1, zc.lastUpdate+1,currentReplacements)
           for(i <- (index + 1) until nodes.length) {
             val n = nodes(i)
             val m = metas(i)
             f(n,i) match {
-              case None => b += ElemsWithContext(m._1, m._2, util.Vector1(n))
-              case Some(r) => b += ElemsWithContext(m._1, zc.lastUpdate + 1 + i - index, r)
+              case None => b += ElemsWithContextVisible(m._1, m._2, util.Vector1(n))
+              case Some(r) => b += ElemsWithContextVisible(m._1, zc.lastUpdate + 1 + i - index, r)
             }
           }
-          for((p,t) <- additionalHoles)
-            b += ElemsWithContext(p,t,util.Vector0)
           
+          for((p,t) <- additionalHoles) {
+            b += ElemsWithContextVisible(p,t,util.Vector0)
+          }
+          
+          b ++= hiddenNodes
+            
           b.result
         }
         
@@ -300,24 +309,51 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
   private[this] class Unselector(context: Context, mergeStrategy: ZipperMergeStrategy) {
     
     /** Each hole is associated with a list of node/time pairs as well as a master update time */
-    type HoleInfo = ZipperHoleMap[(VectorCase[(A,Time)],Time)]
+    type HoleInfo = ZipperHoleMap[(VectorCase[(Node,Time)],Time)]
+    
+    private val initHoleInfoItem:(VectorCase[(Node,Time)],Time) = (util.Vector0,0)
+    
+    type HoleMapGet[A] = A => (ZipperPath, Time, GenTraversableOnce[Node])
+    
+    /** Adding items to the hole info object using the given getter function to transform the items
+     * into the appropriate format. */
+    private def addToHoleInfo[A](items: Seq[A], h: HoleInfo, get: HoleMapGet[A]) = {
+      (h /: items) { (hi, item) =>
+      	val (path, time, nodes) = get(item)
+      	val (oldNodes, oldTime) = hi.getDeep(path).getOrElse(initHoleInfoItem)
+        val newItems = (oldNodes /: nodes) { case(old, node) => old :+ (node, time) }
+        val newTime = math.max(oldTime, time)
+        hi.updatedDeep(path, (newItems, newTime))
+      }
+    }
     
     private val topLevelHoleInfo: HoleInfo = {
-      val Context(_,_,metas,additionalHoles) = context
-      val init:(VectorCase[(A,Time)],Time) = (util.Vector0,0)
-      val hm0: HoleInfo = ZipperHoleMap.empty
-      val hm1 = (hm0 /: (0 until self.length)) { (hm, i) =>
-        val item = self(i)
-        val (path,time) = metas(i)
-        val (oldItems, oldTime) = hm.getDeep(path).getOrElse(init)
-        val newItems = oldItems :+ (item, time)
-        val newTime = math.max(oldTime, time)
-        hm.updatedDeep(path, (newItems, newTime))
+      val Context(_, _, metas, additionalHoles, hiddenNodes) = context
+
+      /* Getters for the different parts of the zipper. */
+      
+      val indicesGet = (i: Int) => {
+        val (path, time) = metas(i)
+        val items = util.Vector1(self(i))
+        (path, time, items)
       }
-      (hm1 /: additionalHoles) { case (hm,(path,time)) =>
-        val (oldItems, oldTime) = hm.getDeep(path).getOrElse(init)
-        val newTime = math.max(oldTime, time)
-        hm.updatedDeep(path, (oldItems, newTime))
+      
+      val hiddenGet = (ewc: ElemsWithContextHidden) => {
+        val ElemsWithContextHidden(path, time, items) = ewc
+        (path, time, items)
+      }
+
+      val additonalGet = (pt: (ZipperPath, Time)) => {
+        val (path, time) = pt
+        (path, time, util.Vector0)
+      }
+      
+      case class ItemsGet[A](items: Seq[A], get: HoleMapGet[A])	  
+      val itemsGetters = List(ItemsGet(indices, indicesGet), ItemsGet(hiddenNodes, hiddenGet), ItemsGet(additionalHoles, additonalGet))
+      
+      val holeInit: HoleInfo = ZipperHoleMap.empty
+      (holeInit /: itemsGetters) { case (hi, ItemsGet(items, get)) =>
+        addToHoleInfo(items, hi, get)
       }
     }
     
@@ -393,8 +429,6 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
 
 object Zipper {
     
-  import CanBuildFromWithZipper.ElemsWithContext
-  
   /**
    * Defines the zipper context
    *
@@ -406,9 +440,15 @@ object Zipper {
    * @param additionalHoles assertions that indicate the specified path is associated with the zipper
    * and has at least the specified time.  If there are paths in this structure that are not in `metas`,
    * then the corresponding hole will be replaced with an empty sequence during `unselect`.  
+   * @param hiddenNodes Nodes that are contained in the Zipper but are not accessible through indexing.
+   * These elements will participate in the unselection process just as the other ones. TODO any special assumptions on these elements?
    */
-  private[antixml] case class Context(parent: Zipper[Node], lastUpdate: Time, 
-          metas: VectorCase[(ZipperPath, Time)], additionalHoles: immutable.Seq[(ZipperPath, Time)])
+  private[antixml] case class Context(
+      parent: Zipper[Node], 
+      lastUpdate: Time, 
+      metas: VectorCase[(ZipperPath, Time)], 
+      additionalHoles: immutable.Seq[(ZipperPath, Time)],
+      hiddenNodes: immutable.Seq[ElemsWithContextHidden])
   
   /** The units in which time is measured in the zipper. Assumed non negative. */
   private type Time = Int
@@ -458,25 +498,36 @@ object Zipper {
     private val itemsBuilder = VectorCase.newBuilder[A]
     private val metasBuilder = VectorCase.newBuilder[(ZipperPath,Time)]
     private val additionalHolesBuilder = new AdditionalHolesBuilder()
-    private var size = 0
+    private val hiddenNodesBuilder = VectorCase.newBuilder[ElemsWithContextHidden]
+    private var size = 0 //TODO is this used anywhere?
     private var maxTime = 0
     
     override def += (ewc: ElemsWithContext[A]) = {      
-      val ElemsWithContext(pseq, time, ns) = ewc
-      val path: ZipperPath = ZipperPath.fromSeq(pseq)
-      val pathTime = (path, time)
-      
-      var nsz = 0
-      for(n <- ns) {
-        itemsBuilder += n
-        metasBuilder += pathTime
-        nsz += 1
+      // keeping track of the time in the context
+      val time: Time = ewc match {
+        case ElemsWithContextVisible(pseq, t, ns) => {
+          val path: ZipperPath = ZipperPath.fromSeq(pseq)
+          val pathTime = (path, t)
+
+          var nsz = 0
+          for (n <- ns) {
+            itemsBuilder += n
+            metasBuilder += pathTime
+            nsz += 1
+          }
+          if (nsz == 0) {
+            additionalHolesBuilder += pathTime
+          }
+
+          size += nsz
+          t
+        }
+        case e @ ElemsWithContextHidden(_, t, _) => {
+          hiddenNodesBuilder += e
+          t
+        }
       }
-      if (nsz==0) {
-        additionalHolesBuilder += pathTime
-      }
       
-      size += nsz
       maxTime = math.max(maxTime, time)
       this            
     }
@@ -484,18 +535,23 @@ object Zipper {
       itemsBuilder.clear()
       metasBuilder.clear()
       additionalHolesBuilder.clear()
+      hiddenNodesBuilder.clear()
       size = 0
       maxTime = 0
     }
     override def result(): Zipper[A] = {
-      val ctx = Context(parent, maxTime, metasBuilder.result(), additionalHolesBuilder.result())
+      val ctx = Context(
+          parent, maxTime, 
+          metasBuilder.result(), 
+          additionalHolesBuilder.result(),
+          hiddenNodesBuilder.result())
       
       new Group[A](itemsBuilder.result()) with Zipper[A] {
         val context = Some(ctx)
       }
     }
   }
-  
+
   /** Builder for the `additionalHoles` list.  This builder ensures that the result has at most one
    *  entry for any given ZipperPath.  Although this isn't necessary for correctness, it ensures that
    *  the `additionalHoles` list remains bounded in size by the total number of holes. 
@@ -521,4 +577,5 @@ object Zipper {
       if (hm.size==0) util.Vector0 
       else (VectorCase.newBuilder[(ZipperPath,Time)] ++= hm).result
   }
+  
 }

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -157,12 +157,12 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
     case None => brokenZipper(nodes.updated(index,node))
   }
   
-  /** TODO */
-  private[antixml] def shiftHoles(shiftFunc: PathTransformer => ZipperPath => Seq[ZipperPath]): Zipper[Node] = context match {
+  /** TODO doc/test */
+  private[antixml] def shiftHoles(shiftFunc: Group[Node] => ZipperPath => Seq[ZipperPath]): Zipper[Node] = context match {
     case Some(context @ Context(parent, lastUpdate, metas, additionalHoles, hiddenNodes)) => {
       implicit val lexicographic = ZipperPathOrdering
       
-      val shift = shiftFunc(PathTransformer(parent))
+      val shift = shiftFunc(parent)
       
       // not allowing duplicates and sorting lexicographical
       val newPaths = SortedSet(metas.flatMap(m => shift(m._1)): _*)

--- a/src/main/scala/com/codecommit/antixml/Zipper.scala
+++ b/src/main/scala/com/codecommit/antixml/Zipper.scala
@@ -183,9 +183,13 @@ trait Zipper[+A <: Node] extends Group[A] with IndexedSeqLike[A, Zipper[A]] { se
       implicit val lexicographic = ZipperPathOrdering
       
       val shift = shiftFunc(parent)
+      val unsoretedPaths = for {
+        m <- metas 
+        path <- shift(m._1) if path != ZipperPath.empty // ignoring empty paths
+      } yield path
       
-      // not allowing duplicates and sorting lexicographically
-      val newPaths = SortedSet(metas.flatMap(m => shift(m._1)): _*)
+      // not allowing duplicates and empty paths and sorting lexicographically
+      val newPaths = SortedSet(unsoretedPaths: _*)
       val holeInfo = new HoleMapper(context).holeInfo
       
       val b = newZipperContextBuilder[Node](Some(parent))

--- a/src/main/scala/com/codecommit/antixml/ZipperAxes.scala
+++ b/src/main/scala/com/codecommit/antixml/ZipperAxes.scala
@@ -1,0 +1,71 @@
+package com.codecommit.antixml
+import scala.annotation.tailrec
+
+/**
+ * Wraps [[com.codecommit.antixml.Zipper]] instances with some XPath like axes.
+ * 
+ * Note1: the axes are applied to each node in a zipper individually and the result
+ * is a new zipper with the nodes concatenated and sorted lexicographically by
+ * location (removing any duplicate locations).
+ * 
+ * Note2: the axes are calculated using holes in the zipper, hence for a modified
+ * zipper some nodes may be multiplied or elided.
+ */
+class ZipperAxes(zipper: Zipper[Node]) {
+  /** Returns the direct parent of a node. */
+  def directParent = {
+    zipper shiftHoles (g => (PathTransformer(g).shiftUp(_)).andThen(_.toList))
+  }
+  
+  /** Returns the ancestors of a node. */
+  def ancestor = transFuncToShift(_.shiftUp, false)
+
+  /** Returns the ancestors of a node including itself. */
+  def ancestorOrSelf = transFuncToShift(_.shiftUp, true)
+  
+  /** Returns the following siblings of a node. */
+  def followingSibling = transFuncToShift(_.shiftRight, false)
+  
+  /** Returns the following siblings of a node including itself. */
+  def followingSiblingOrSelf = transFuncToShift(_.shiftRight, true)
+
+  /** Returns the preceding siblings of a node. */
+  def precedingSibling = transFuncToShift(_.shiftLeft, false)
+  
+  /** Returns the preceding siblings of a node including itself. */
+  def precedingSiblingOrSelf = transFuncToShift(_.shiftLeft, true)
+
+  /** Takes a path transformer function and converts it to a shifting function which is applied until
+   *  the transformer return `None`.
+   *  @param appendSource True if the initial path should be part of the result.
+   */
+  private def transFuncToShift(func: PathTransformer => ZipperPath => Option[ZipperPath], withSource: Boolean) = {
+    zipper shiftHoles { g =>
+      val pathToOpt = func(PathTransformer(g))
+
+      @tailrec
+      def traverse(path: ZipperPath, res: List[ZipperPath]): List[ZipperPath] = {
+        val opt = pathToOpt(path)
+        opt match {
+          case None => res
+          case Some(p) => traverse(p, p :: res)
+        }
+      }
+
+      val shiftFunc = (p: ZipperPath) => {
+        val init =
+          if (withSource) List(p)
+          else List()
+        traverse(p, init)
+      }
+      shiftFunc
+    }
+  }
+  
+}
+
+object ZipperAxes {
+	/** Pimps a plain zipper to have axes selection methods. 
+	 * TODO move to package object? */
+	implicit def zipperToAxes(zipper: Zipper[Node]) = new ZipperAxes(zipper)
+}

--- a/src/main/scala/com/codecommit/antixml/ZipperHoleMap.scala
+++ b/src/main/scala/com/codecommit/antixml/ZipperHoleMap.scala
@@ -106,6 +106,8 @@ private[antixml] final class ZipperHoleMap[+B] private (items: Map[Int, ZipperHo
 
   /** Returns a traversable represented the tree's contents in pre-order (lexicographically by path).
    * Note that this has not been optimized, as it is only currently used by toString and for testing.
+   * 
+   * TODO using this for zipper shifting, consider optimizing
    */
   def depthFirst: Traversable[(ZipperPath, B)] = 
     new Traversable[(ZipperPath, B)] {

--- a/src/main/scala/com/codecommit/antixml/ZipperHoleMap.scala
+++ b/src/main/scala/com/codecommit/antixml/ZipperHoleMap.scala
@@ -105,7 +105,7 @@ private[antixml] final class ZipperHoleMap[+B] private (items: Map[Int, ZipperHo
   }
 
   /** Returns a traversable represented the tree's contents in pre-order (lexicographically by path).
-   * Note that this has not been optimized, as it is only currenly used by toString and for testing.
+   * Note that this has not been optimized, as it is only currently used by toString and for testing.
    */
   def depthFirst: Traversable[(ZipperPath, B)] = 
     new Traversable[(ZipperPath, B)] {

--- a/src/test/scala/com/codecommit/antixml/PathFetcherSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/PathFetcherSpecs.scala
@@ -1,0 +1,37 @@
+package com.codecommit.antixml
+
+import org.specs2.mutable._
+import org.specs2.matcher.DataTables
+import XML._
+
+class PathFetcherSpecs extends SpecificationWithJUnit with DataTables {
+  
+  val x0 = fromString("<root0><a0>foo</a0><b0>baz</b0><c0/></root0>")
+  val x1 = fromString("<root1><a1>foo</a1><b1>baz</b1><c1/></root1>")
+  val x2 = fromString("<root2><a2>foo</a2><b2>baz</b2><c2/></root2>")
+
+  val group = Group(x0, x1, x2)
+  val fetch = PathFetcher.getNode(group)_
+  val empty: Option[Node] = None
+  
+  "path fetching" should {
+    "produce correct results" in {
+        "path"           | "result" |
+        ZipperPath.empty !  empty   |
+        ZipperPath(0)    ! Some(x0) |
+        ZipperPath(1)    ! Some(x1) |
+        ZipperPath(2)    ! Some(x2) | 
+        ZipperPath(0, 0) ! Some(fromString("<a0>foo</a0>")) |
+        ZipperPath(0, 1) ! Some(fromString("<b0>baz</b0>")) |
+		ZipperPath(0, 2) ! Some(fromString("<c0/>")) |
+		ZipperPath(1, 0) ! Some(fromString("<a1>foo</a1>")) |
+		ZipperPath(1, 1) ! Some(fromString("<b1>baz</b1>")) |
+		ZipperPath(1, 2) ! Some(fromString("<c1/>")) |
+		ZipperPath(2, 0) ! Some(fromString("<a2>foo</a2>")) |
+		ZipperPath(2, 1) ! Some(fromString("<b2>baz</b2>")) |
+		ZipperPath(2, 2) ! Some(fromString("<c2/>")) |> { 
+         (path, res) => fetch(path) mustEqual res
+        }
+    }
+  }
+}

--- a/src/test/scala/com/codecommit/antixml/PathTransformerSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/PathTransformerSpecs.scala
@@ -1,18 +1,18 @@
 package com.codecommit.antixml
 
 import org.specs2.mutable._
+import org.specs2.matcher.DataTables
 import XML._
-import scala.collection.immutable.HashMap
 
-class PathTransformerSpecs extends SpecificationWithJUnit {
+class PathTransformerSpecs extends SpecificationWithJUnit with DataTables {
   
   val x0 = fromString("<root0><a0>foo</a0><b0>baz</b0><c0/></root0>")
   val x1 = fromString("<root1><a1>foo</a1><b1>baz</b1><c1/></root1>")
   val x2 = fromString("<root2><a2>foo</a2><b2>baz</b2><c2/></root2>")
-
+  
   val group = Group(x0, x1, x2)
   
-  val empty = ZipperPath()
+  val empty = ZipperPath.empty
   val p1 = ZipperPath(0, 1, 0)
   val p2 = ZipperPath(1, 1)
   val p3 = ZipperPath(2)
@@ -26,9 +26,12 @@ class PathTransformerSpecs extends SpecificationWithJUnit {
     }
     
     "properly shift paths" in {
-      transformer.shiftUp(p1) mustEqual Some(ZipperPath(0, 1))
-      transformer.shiftUp(p2) mustEqual Some(ZipperPath(1))
-      transformer.shiftUp(p3) mustEqual Some(ZipperPath())
+      "path" | "result" |
+      p1     ! Some(ZipperPath(0, 1)) |
+      p2     ! Some(ZipperPath(1)) |
+      p3     ! Some(ZipperPath()) |> {
+       (path, res) => transformer.shiftUp(path) mustEqual res
+      }
     }
   }
   
@@ -38,10 +41,13 @@ class PathTransformerSpecs extends SpecificationWithJUnit {
     }
     
     "properly shift paths" in {
-      transformer.shiftLeft(p1) mustEqual None
-      transformer.shiftLeft(p2) mustEqual Some(ZipperPath(1, 0))
-      transformer.shiftLeft(p3) mustEqual Some(ZipperPath(1))
-      transformer.shiftLeft(p4) mustEqual None
+      "path" | "result" |
+        p1   ! None.asInstanceOf[Option[ZipperPath]] |
+        p2   ! Some(ZipperPath(1, 0)) |
+        p3   ! Some(ZipperPath(1)) |
+        p4   ! None |> {
+          (path, res) => transformer.shiftLeft(path) mustEqual res
+        }
     }
   }
   
@@ -49,13 +55,16 @@ class PathTransformerSpecs extends SpecificationWithJUnit {
 	  "fail on empty paths" in {
 		  transformer.shiftRight(empty) must throwAn[AssertionError]
 	  }
-	  
-	  "properly shift paths" in {
-		  transformer.shiftRight(p1) mustEqual None
-		  transformer.shiftRight(p2) mustEqual Some(ZipperPath(1, 2))
-		  transformer.shiftRight(p3) mustEqual None
-		  transformer.shiftRight(p4) mustEqual Some(ZipperPath(1))
-	  }
+
+    "properly shift paths" in {
+      "path" | "result" |
+        p1   ! None.asInstanceOf[Option[ZipperPath]] |
+        p2   ! Some(ZipperPath(1, 2)) |
+        p3   ! None |
+        p4   ! Some(ZipperPath(1)) |> {
+          (path, res) => transformer.shiftRight(path) mustEqual res
+        }
+    }
   }
   
   def elem(name: String, text: String) = Elem(None, name, Attributes(), Map(), Group(Text(text)))

--- a/src/test/scala/com/codecommit/antixml/PathTransformerSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/PathTransformerSpecs.scala
@@ -27,9 +27,9 @@ class PathTransformerSpecs extends SpecificationWithJUnit with DataTables {
     
     "properly shift paths" in {
       "path" | "result" |
-      p1     ! Some(ZipperPath(0, 1)) |
+      p1     ! Some(ZipperPath(0, 1)).asInstanceOf[Option[ZipperPath]] |
       p2     ! Some(ZipperPath(1)) |
-      p3     ! Some(ZipperPath()) |> {
+      p3     ! None |> {
        (path, res) => transformer.shiftUp(path) mustEqual res
       }
     }

--- a/src/test/scala/com/codecommit/antixml/PathTransformerSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/PathTransformerSpecs.scala
@@ -1,0 +1,62 @@
+package com.codecommit.antixml
+
+import org.specs2.mutable._
+import XML._
+import scala.collection.immutable.HashMap
+
+class PathTransformerSpecs extends SpecificationWithJUnit {
+  
+  val x0 = fromString("<root0><a0>foo</a0><b0>baz</b0><c0/></root0>")
+  val x1 = fromString("<root1><a1>foo</a1><b1>baz</b1><c1/></root1>")
+  val x2 = fromString("<root2><a2>foo</a2><b2>baz</b2><c2/></root2>")
+
+  val group = Group(x0, x1, x2)
+  
+  val empty = ZipperPath()
+  val p1 = ZipperPath(0, 1, 0)
+  val p2 = ZipperPath(1, 1)
+  val p3 = ZipperPath(2)
+  val p4 = ZipperPath(0)
+  
+  val transformer = PathTransformer(group)
+  
+  "shifting upwards" should {
+    "ignore empty paths" in {
+      transformer.shiftUp(empty) mustEqual None
+    }
+    
+    "properly shift paths" in {
+      transformer.shiftUp(p1) mustEqual Some(ZipperPath(0, 1))
+      transformer.shiftUp(p2) mustEqual Some(ZipperPath(1))
+      transformer.shiftUp(p3) mustEqual Some(ZipperPath())
+    }
+  }
+  
+  "shifting leftwards" should {
+    "fail on empty paths" in {
+      transformer.shiftLeft(empty) must throwAn[AssertionError]
+    }
+    
+    "properly shift paths" in {
+      transformer.shiftLeft(p1) mustEqual None
+      transformer.shiftLeft(p2) mustEqual Some(ZipperPath(1, 0))
+      transformer.shiftLeft(p3) mustEqual Some(ZipperPath(1))
+      transformer.shiftLeft(p4) mustEqual None
+    }
+  }
+  
+  "shifting rightwards" should {
+	  "fail on empty paths" in {
+		  transformer.shiftRight(empty) must throwAn[AssertionError]
+	  }
+	  
+	  "properly shift paths" in {
+		  transformer.shiftRight(p1) mustEqual None
+		  transformer.shiftRight(p2) mustEqual Some(ZipperPath(1, 2))
+		  transformer.shiftRight(p3) mustEqual None
+		  transformer.shiftRight(p4) mustEqual Some(ZipperPath(1))
+	  }
+  }
+  
+  def elem(name: String, text: String) = Elem(None, name, Attributes(), Map(), Group(Text(text)))
+}

--- a/src/test/scala/com/codecommit/antixml/ZipperAxesSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperAxesSpecs.scala
@@ -1,0 +1,154 @@
+package com.codecommit.antixml
+
+import org.specs2.mutable._
+import XML._
+import ZipperAxes._
+import scala.collection.immutable.SortedSet
+
+class ZipperAxesSpecs extends SpecificationWithJUnit {
+  val bookstore = resource("bookstore.xml").toGroup
+  
+  "Axes" should {
+    "preserve past modifications" in {
+      val zipper = (bookstore \\ 'author).updated(3, Text("foo"))
+      val res = zipper.unselect
+      
+      zipper.directParent.unselect mustEqual res
+      zipper.ancestor.unselect mustEqual res
+      zipper.ancestorOrSelf.unselect mustEqual res
+      zipper.followingSibling.unselect mustEqual res
+      zipper.followingSiblingOrSelf.unselect mustEqual res
+      zipper.precedingSibling.unselect mustEqual res
+      zipper.precedingSiblingOrSelf.unselect mustEqual res
+    }
+    
+    "fail on broken zippers" in {
+      bookstore.toZipper.directParent.unselect must throwA[RuntimeException]
+      bookstore.toZipper.ancestor.unselect must throwA[RuntimeException]
+      bookstore.toZipper.ancestorOrSelf.unselect must throwA[RuntimeException]
+      bookstore.toZipper.followingSibling.unselect must throwA[RuntimeException]
+      bookstore.toZipper.followingSiblingOrSelf.unselect must throwA[RuntimeException]
+      bookstore.toZipper.precedingSibling.unselect must throwA[RuntimeException]
+      bookstore.toZipper.precedingSiblingOrSelf.unselect must throwA[RuntimeException]
+    }
+  }
+  
+  "Direct parent axes" should {
+    "be empty for root" in {
+      val res = bookstore select 'bookstore directParent
+      
+      res mustEqual Group()
+      res.unselect mustEqual bookstore
+    }
+    
+    "return the direct parents of nodes" in {
+      val res = bookstore \\ 'author directParent;
+      
+      res mustEqual (bookstore \\ 'book)
+      res.unselect mustEqual bookstore
+    }
+  }
+  
+  "Ancestor axes" should {
+    "be empty for root" in {
+      val res = bookstore select 'bookstore ancestor
+      
+      res mustEqual Group()
+      res.unselect mustEqual bookstore
+    }
+    
+    "return all ancestors of nodes" in {
+      val res = bookstore \\ 'author ancestor;
+      
+      res mustEqual (bookstore ++ bookstore \\ 'book)
+      res.unselect mustEqual bookstore
+    }
+  }
+  
+  "Ancestor or self axes" should {
+    "return self for root" in {
+      val res = bookstore select 'bookstore ancestorOrSelf
+      
+      res mustEqual bookstore
+      res.unselect mustEqual bookstore
+    }
+    
+    "return all ancestors and self of nodes" in {
+      val books = bookstore \\ 'book
+      val authors = bookstore \\ 'author
+      
+      val res = authors ancestorOrSelf;
+      
+      
+      res mustEqual (bookstore :+ books(0) :+ authors(0) :+ books(1) :+ authors(1) :+ books(2) :+ authors(2) :+ authors(3))
+      res.unselect mustEqual bookstore
+    }
+  }
+  
+  "Following sibling axes" should {
+    "return nothing on rightmost node" in {
+      val res = bookstore \\ 'author followingSibling
+      
+      res mustEqual Group((bookstore \\ 'author).apply(3))
+      res.unselect mustEqual bookstore
+    }
+    
+    "return all following siblings of nodes" in {
+      val res = bookstore \\ 'title followingSibling
+      
+      res mustEqual bookstore \\ 'author 
+      res.unselect mustEqual bookstore
+    }
+  }
+  
+  "Following sibling or self axes" should {
+    "return self for rightmost nodes" in {
+      val res = bookstore \\ 'author followingSiblingOrSelf
+      
+      res mustEqual (bookstore \\ 'author)
+      res.unselect mustEqual bookstore
+    }
+    
+    "return all following siblings and self of nodes" in {
+      val res = bookstore \\ 'title followingSiblingOrSelf
+      
+      res mustEqual bookstore \ 'book \ *
+      res.unselect mustEqual bookstore
+    }
+  }
+  
+  "Preceding sibling axes" should {
+    "return nothing on leftmost node" in {
+      val res = bookstore \\ 'title precedingSibling
+      
+      res mustEqual Group()
+      res.unselect mustEqual bookstore
+    }
+    
+    "return all preceding siblings of nodes" in {
+      val res = bookstore \\ 'author precedingSibling
+      
+      res mustEqual (bookstore \\ 'title) :+ (bookstore \\ 'author).apply(2)
+      res.unselect mustEqual bookstore
+    }
+  }
+  
+  "Preceding sibling or self axes" should {
+    "return self for leftmost nodes" in {
+      val res = bookstore \\ 'title precedingSiblingOrSelf
+      
+      res mustEqual (bookstore \\ 'title)
+      res.unselect mustEqual bookstore
+    }
+    
+    "return all preceding siblings and self of nodes" in {
+      val res = bookstore \\ 'author precedingSiblingOrSelf
+      
+      res mustEqual bookstore \ 'book \ *
+      res.unselect mustEqual bookstore
+    }
+  }
+
+  def resource(filename: String) =
+    XML fromSource (scala.io.Source fromURL (getClass getResource ("/" + filename)))
+}

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -972,6 +972,13 @@ class ZipperSpecs extends SpecificationWithJUnit with ScalaCheck  with XMLGenera
       shifted.unselect mustEqual group
     }
     
+    "ignore empty paths" in {
+      val shifted = zipper shiftHoles makeConstShift(Seq(ZipperPath.empty))
+      
+      shifted mustEqual Group()
+      shifted.unselect mustEqual group
+    }
+    
     "result in a lexicographic set" in {
       val shifted = zipper shiftHoles constantShift
       shifted mustEqual constShiftRes

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -965,6 +965,13 @@ class ZipperSpecs extends SpecificationWithJUnit with ScalaCheck  with XMLGenera
       shifted.unselect mustEqual group
     }
     
+    "handle empty results" in {
+      val shifted = zipper shiftHoles makeConstShift(Seq())
+      
+      shifted mustEqual Group()
+      shifted.unselect mustEqual group
+    }
+    
     "result in a lexicographic set" in {
       val shifted = zipper shiftHoles constantShift
       shifted mustEqual constShiftRes

--- a/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
+++ b/src/test/scala/com/codecommit/antixml/ZipperSpecs.scala
@@ -45,26 +45,6 @@ class ZipperSpecs extends SpecificationWithJUnit with ScalaCheck  with XMLGenera
   // TODO This is by no means exhaustive, just showing off what's possible.
 
   "Deep Zipper selection" should {
-    // I'm lazy so the bookstore is hardcoded here.
-	// From some reason parsing indented literals gives errors when comparing results, using a single line string.
-    
-    val bookstore = fromString {
-      "<bookstore>" +
-        "<book>" +
-          "<title>For Whom the Bell Tolls</title>" +
-          "<author>Hemmingway</author>" +
-        "</book>" +
-        "<book>" +
-          "<title>I, Robot</title>" +
-          "<author>Isaac Asimov</author>" +
-        "</book>" +
-        "<book>" +
-          "<title>Programming Scala</title>" +
-          "<author>Dean Wampler</author>" +
-          "<author>Alex Payne</author>" +
-        "</book>" +
-      "</bookstore>" 
-    }
       
     val bookGroup = Group(bookstore)
 
@@ -953,7 +933,86 @@ class ZipperSpecs extends SpecificationWithJUnit with ScalaCheck  with XMLGenera
 
     }
   }
-  
+
+  "zipper shifting" should {
+    val x0 = fromString("<root0><a>foo0</a><b>baz0</b><c/></root0>")
+    val x1 = fromString("<root1><a>foo1</a><b>baz1</b><c/></root1>")
+    val x2 = fromString("<root2><a>foo2</a><b>baz2</b><c/></root2>")
+    val root = <root />.convert
+    
+    def updateRoot(c: Group[Node]) = root.copy(children = c).toGroup
+
+    val group = root.copy(children = Group(x0, x1, x2)).toGroup
+    val zipper = group \ *
+    
+    val noShift = (g: Any) => (p: ZipperPath) => Seq(p)
+    
+    def makeConstShift(paths: Seq[ZipperPath]) = (g: Any) => (p: Any) => paths
+
+    val constantShift = makeConstShift(Seq(ZipperPath(0, 1), ZipperPath(0, 2), ZipperPath(0, 1), ZipperPath(0, 0)))
+    val constShiftRes = Group(x0, x1, x2)
+    
+    
+    
+    "fail on a broken zipper" in {
+      group.toZipper.shiftHoles(noShift) must throwA[RuntimeException]
+    }
+    
+    "preserve zipper when not shifting" in {
+      val shifted = zipper shiftHoles noShift
+      
+      shifted mustEqual zipper
+      shifted.unselect mustEqual group
+    }
+    
+    "result in a lexicographic set" in {
+      val shifted = zipper shiftHoles constantShift
+      shifted mustEqual constShiftRes
+      shifted.unselect mustEqual group
+    }
+    
+    "preserve elided holes" in {
+      val sliced = zipper.slice(1, 2)
+      val shifted = sliced shiftHoles constantShift
+      
+      shifted mustEqual Group(x1) // x0 and x2 were removed by slicing
+      shifted.unselect mustEqual updateRoot(Group(x1))
+    }
+    
+    "preserve multiplied holes" in {
+      val flatMapped = zipper flatMap (n => Seq(n, n))
+      val shifted = flatMapped shiftHoles constantShift
+      val children = Group(x0, x0, x1, x1, x2, x2)
+
+      shifted mustEqual children
+      shifted.unselect mustEqual updateRoot(children)
+    }
+    
+    "preserve previous updates" in {
+      val update = <update />.convert
+      val updated = zipper.updated(1, update)
+      val children = Group(x0, update, x2)
+      val shifted = updated shiftHoles constantShift
+      
+      shifted mustEqual children
+      shifted.unselect mustEqual updateRoot(children)
+    }
+    
+    "maintain hidden holes through multiple shifts (a.k.a 'all together now')" in {
+      val update = <update />.convert
+      
+      val shift1 = zipper.slice(1, 2) shiftHoles constantShift
+      val shift2 = shift1 flatMap (n => Seq(n, n)) shiftHoles makeConstShift(Seq(ZipperPath(0, 0, 0)))
+      val shift3 = shift2.updated(0, update) shiftHoles makeConstShift(Seq(ZipperPath(0, 1, 2)))
+      val shift4 = shift3.updated(0, update) shiftHoles makeConstShift(Seq(ZipperPath(0, 0)))
+      
+      shift4 mustEqual Group()
+      
+      val child = x1.copy(children = x1.children.updated(2, update))
+      shift4.unselect mustEqual updateRoot(Group(child, child))
+    }
+    
+  }
   
   def validate[Expected] = new {
     def apply[A](a: A)(implicit evidence: A =:= Expected) = evidence must not beNull


### PR DESCRIPTION
This batch of commits adds partial XPath like axes support (via pimping) to Zipper.

This is done using the ZipperAxes class and the shiftHoles method on ZIpper, see the corresponding Specs for examples.

There is no support for the child axes (although it is possible) as this can be achieved via simple selection.
Though some inconsistency arises when mixing axes manipulation and selection: specifying an axes doesn't force another `unselect` call to produce the original group, while selection does, e.g.:

``` scala
val group = ...
val zipper = group \\ ...

zipper.ancestor.unselect == group
zipper.select(...).unselect.unselect == group
```

Note: practically no considerations of efficiency were made, and there are probably multiple redundant traversals of the XML tree while calculating and fetching the different axes.
